### PR TITLE
ffmemless: Adding constant and custom periodic effects. Upload before play.

### DIFF
--- a/src/plugins/ffmemless/ffmemless.h
+++ b/src/plugins/ffmemless/ffmemless.h
@@ -35,21 +35,22 @@ int ffmemless_erase_effect(int effect_id, int device_file);
  * of force feedback effects and returns the file pointer if it does.
  *
  * @param device_file_name A pointer to file name. E.g. "/dev/input/event2"
+ * @param features An array of 4 longs to be tested with FF_test_bit for features.
  * @returns File descriptor on success, -1 on error.
  */
-int ffmemless_evdev_file_open(const char *device_file_name);
+int ffmemless_evdev_file_open(const char *device_file_name, unsigned long features[4]);
 
 /**
  * ffmemless_evdev_file_search - Search first device node with FF support.
  *
  * This function searches through /dev/input/event? files for first one that
- * supports FF_RUMBLE and FF_PRERIODIC type of force feedback effects. Once
- * a device node is found, the function returns a open file descriptor
- * to the device node.
+ * supports either FF_RUMBLE or FF_CONSTANT but also FF_PRERIODIC type of force
+ * feedback effects. Once a device node is found, the function returns a open file
+ * descriptor to the device node.
  *
  * @returns	File descriptor on success, -1 if no suitable device node found.
  */
-int ffmemless_evdev_file_search(void);
+int ffmemless_evdev_file_search(unsigned long features[4]);
 
 /**
  * ffmemless_evdev_file_close - Close a event device node.
@@ -59,5 +60,7 @@ int ffmemless_evdev_file_search(void);
  * @returns 0 on success, -1 on error.
  */
 int ffmemless_evdev_file_close(int device_file);
+
+int ffmemless_has_feature(__u16 type, unsigned long features[4]);
 
 #endif

--- a/src/plugins/ffmemless/plugin.c
+++ b/src/plugins/ffmemless/plugin.c
@@ -37,15 +37,20 @@
 #define FFM_SYSTEM_CONFIG_KEY	"system_effects_env"
 #define FFM_DEVFILE_KEY		"device_file_path"
 #define FFM_EFFECTLIST_KEY	"supported_effects"
+#define FFM_CACHE_EFFECTS_KEY	"cache_effects"
 #define FFM_SOUND_REPEAT_KEY	"sound.repeat"
 #define FFM_HAPTIC_DURATION_KEY	"haptic.duration"
 #define FFM_MAX_PARAM_LEN	80
 
-#define NGF_DEFAULT_TYPE	FF_RUMBLE
 #define NGF_DEFAULT_DURATION	240
 #define NGF_DEFAULT_DELAY	0
+// rumble
 #define NGF_DEFAULT_RMAGNITUDE	27000
 #define NGF_DEFAULT_PMAGNITUDE	14000
+// constant
+#define NGF_DEFAULT_LEVEL 0x5FFF
+
+#define CUSTOM_DATA_LEN 3
 
 N_PLUGIN_NAME(FFM_PLUGIN_NAME)
 N_PLUGIN_DESCRIPTION("Vibra plugin using ff-memless kernel backend")
@@ -58,6 +63,8 @@ struct ffm_effect_data {
 	int repeat;
 	guint playback_time;
 	int poll_id;
+	int16_t customEffectId;
+	struct ff_effect cached_effect;
 };
 
 static struct ffm_data {
@@ -65,6 +72,8 @@ static struct ffm_data {
 	const NProplist *ngfd_props;
 	NProplist *sys_props;
 	GHashTable	*effects;
+	gboolean cache_effects;
+	unsigned long features[4];
 } ffm;
 
 static int ffm_setup_device(const NProplist *props, int *dev_fd)
@@ -74,17 +83,17 @@ static int ffm_setup_device(const NProplist *props, int *dev_fd)
 	if (device_file == NULL) {
 		N_DEBUG (LOG_CAT "No %s provided, using automatic detection",
 					FFM_DEVFILE_KEY);
-		*dev_fd = ffmemless_evdev_file_search();
+		*dev_fd = ffmemless_evdev_file_search(ffm.features);
 	} else {
 		N_DEBUG (LOG_CAT "%s found with value \"%s\"",
 					FFM_DEVFILE_KEY, device_file);
-		*dev_fd = ffmemless_evdev_file_open(device_file);
+		*dev_fd = ffmemless_evdev_file_open(device_file, ffm.features);
 		/* do a fall back to automatic search, in case open fails */
 		if (*dev_fd == -1) {
 			N_DEBUG (LOG_CAT "%s is not a valid event device",
 					device_file);
 			N_DEBUG (LOG_CAT "Falling back to automatic detection");
-			*dev_fd = ffmemless_evdev_file_search();
+			*dev_fd = ffmemless_evdev_file_search(ffm.features);
 		}
 	}
 	if (*dev_fd == -1) {
@@ -241,8 +250,7 @@ static int ffm_setup_default_effect(GHashTable *effects, int dev_fd)
 	data = (struct ffm_effect_data *)g_hash_table_lookup(effects,
 							N_HAPTIC_EFFECT_DEFAULT);
 	if (!data) {
-		data = g_new(struct ffm_effect_data, 1);
-		data->id = -1;
+		data = g_new0(struct ffm_effect_data, 1);
 		data->id = 1;
 		ff.id = -1;
 		g_hash_table_insert(effects, g_strdup(N_HAPTIC_EFFECT_DEFAULT),
@@ -251,15 +259,34 @@ static int ffm_setup_default_effect(GHashTable *effects, int dev_fd)
 		ff.id = data->id;
 	}
 
-	ff.type = FF_RUMBLE;
-	ff.replay.length = NGF_DEFAULT_DURATION;
-	ff.u.rumble.strong_magnitude = NGF_DEFAULT_RMAGNITUDE;
-	ff.u.rumble.weak_magnitude = NGF_DEFAULT_RMAGNITUDE;
+	N_DEBUG (LOG_CAT "Features array is %lx %lx %lx %lx", ffm.features[0],
+		ffm.features[1], ffm.features[2], ffm.features[3]);
+	// We test first for FF_CONSTANT because FF_RUMBLE may be falsely reported by
+	// input_ff_create if FF_PERIODIC is supported. However, there are some
+	// drivers which use FF_PERIODIC only with FF_CUSTOM waveform..
+	// https://github.com/torvalds/linux/blob/master/drivers/input/ff-core.c#L350
+	if (ffmemless_has_feature(FF_CONSTANT, ffm.features)) {
+		N_DEBUG (LOG_CAT "Using constant default effect, rumble is %d", 
+			(ffmemless_has_feature(FF_RUMBLE, ffm.features)));
+		ff.type = FF_CONSTANT;
+		ff.replay.length = NGF_DEFAULT_DURATION;
+		ff.u.constant.level = NGF_DEFAULT_LEVEL;
+	} else {
+		N_DEBUG (LOG_CAT "Using rumble default effect");
+		ff.type = FF_RUMBLE;
+		ff.replay.length = NGF_DEFAULT_DURATION;
+		ff.u.rumble.strong_magnitude = NGF_DEFAULT_RMAGNITUDE;
+		ff.u.rumble.weak_magnitude = NGF_DEFAULT_RMAGNITUDE;
+	}
+	if (ffm.cache_effects) {
+		memcpy(&data->cached_effect, &ff, sizeof(ff));
+	}
 	if (ffmemless_upload_effect(&ff, dev_fd)) {
 		N_DEBUG (LOG_CAT "%s effect load failed", N_HAPTIC_EFFECT_DEFAULT);
 		return -1;
 	}
 	data->id = ff.id;
+
 	N_DEBUG (LOG_CAT "Added effect %s, id %d", N_HAPTIC_EFFECT_DEFAULT, ff.id);
 	return 0;
 }
@@ -292,6 +319,7 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 	while (g_hash_table_iter_next(&iter, (gpointer) &key,
 							(gpointer) &data)) {
 		memset(&ff, 0, sizeof(struct ff_effect));
+		int16_t custom_data[CUSTOM_DATA_LEN] = {0, 0, 0};
 		N_DEBUG (LOG_CAT "got key %s, id %d", key, data->id);
 
 		value = ffm_get_str_value(props, key, "_TYPE");
@@ -308,6 +336,8 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 			ff.type = FF_RUMBLE;
 		} else if (!strcmp(value, "periodic")) {
 			ff.type = FF_PERIODIC;
+		} else if (!strcmp(value, "constant")) {
+			ff.type = FF_CONSTANT;
 		} else {
 			N_WARNING (LOG_CAT "unknown effect type %s", value);
 			continue;
@@ -363,7 +393,29 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 			/* Usually no separate weak motor, use same value */
 			ff.u.rumble.weak_magnitude =
 						ff.u.rumble.strong_magnitude;
+		} else if (ff.type == FF_CONSTANT) {
+			N_DEBUG (LOG_CAT "constant effect");
+			ff.type = FF_CONSTANT;
 
+			int level = ffm_get_int_value(props,
+				key, "_LEVEL", INT32_MIN, INT32_MAX);
+			ff.u.constant.level = level == INT32_MIN ? 0 : (__s16)level;
+
+			ff.u.constant.envelope.attack_length = ffm_get_int_value(
+				props, key, "_ATTACK",
+				0, UINT16_MAX);
+
+			ff.u.constant.envelope.attack_level = ffm_get_int_value(
+				props, key, "_ALEVEL",
+				0, UINT16_MAX);
+
+			ff.u.constant.envelope.fade_length = ffm_get_int_value(
+				props, key, "_FADE",
+				0, UINT16_MAX);
+
+			ff.u.constant.envelope.fade_level = ffm_get_int_value(
+				props, key, "_FLEVEL",
+				0, UINT16_MAX);
 		} else if (ff.type == FF_PERIODIC) {
 			N_DEBUG (LOG_CAT "periodic effect");
 			ff.type = FF_PERIODIC;
@@ -374,8 +426,18 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 				ff.u.periodic.waveform = FF_SQUARE;
 			else if (!g_strcmp0(value, "triangle"))
 				ff.u.periodic.waveform = FF_TRIANGLE;
+			else if (!g_strcmp0(value, "custom"))
+				ff.u.periodic.waveform = FF_CUSTOM;
 			else
 				ff.u.periodic.waveform = FF_SINE;
+
+			if (ff.u.periodic.waveform == FF_CUSTOM) {
+				data->customEffectId = ffm_get_int_value(props,
+					key, "_CUSTOM", 0, UINT16_MAX);
+				custom_data[0] = data->customEffectId;
+				ff.u.periodic.custom_data = custom_data;
+				ff.u.periodic.custom_len = CUSTOM_DATA_LEN;
+			}
 
 			ff.u.periodic.period = ffm_get_int_value(props,
 				key, "_PERIOD", 0, UINT16_MAX);
@@ -425,8 +487,20 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 		/* If the id was -1, kernel has updated it with valid value */
 		data->id = ff.id;
 		/* Calculate the playback time */
-		data->playback_time = data->repeat *
-					(ff.replay.delay + ff.replay.length);
+		if (ff.type == FF_PERIODIC && ff.u.periodic.waveform == FF_CUSTOM) {
+			data->playback_time = ff.u.periodic.custom_data[1] * 1000
+				+ ff.u.periodic.custom_data[2];
+			N_DEBUG(LOG_CAT "Custom effect %d reports back %hd ms playback time",
+				ff.id, data->playback_time);
+		} else {
+			data->playback_time = data->repeat *
+				(ff.replay.delay + ff.replay.length);
+		}
+
+		if (ffm.cache_effects) {
+			memcpy(&data->cached_effect, &ff, sizeof(ff));
+		}
+
 		N_DEBUG (LOG_CAT "Created effect %s with id %d", key, data->id);
 		N_DEBUG (LOG_CAT "Parameters:\n"
 			"type = 0x%x\n"
@@ -434,6 +508,7 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 			"delay = %dms\n"
 			"strong rumble magn = 0x%x\n"
 			"weak rumble magn = 0x%x\n"
+			"const level = 0x%d\n"
 			"per_waveform = 0x%x\n"
 			"period = %dms\n"
 			"periodic magnitude = 0x%x\n"
@@ -443,11 +518,13 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 			"att_lev = 0x%x\n"
 			"fade = %ums\n"
 			"fade_lev = 0x%x\n",
+			"custom_len = %d\n",
 			ff.type,
 			ff.replay.length,
 			ff.replay.delay,
 			ff.u.rumble.strong_magnitude,
 			ff.u.rumble.weak_magnitude,
+			ff.u.constant.level,
 			ff.u.periodic.waveform,
 			ff.u.periodic.period,
 			ff.u.periodic.magnitude,
@@ -456,11 +533,11 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 			ff.u.periodic.envelope.attack_length,
 			ff.u.periodic.envelope.attack_level,
 			ff.u.periodic.envelope.fade_length,
-			ff.u.periodic.envelope.fade_level);
+			ff.u.periodic.envelope.fade_level,
+			ff.u.periodic.custom_len);
 	}
 
 	return 0;
-
 ffm_eff_error1:
 	g_hash_table_destroy(ffm.effects);
 	return -1;
@@ -472,6 +549,9 @@ gboolean ffm_playback_done(gpointer userdata)
 
 	N_DEBUG (LOG_CAT "Effect id %d completed", data->id);
 
+	if (ffm.cache_effects) {
+		ffmemless_erase_effect(data->cached_effect.id, ffm.dev_file);
+	}
 	data->poll_id = 0;
 	n_sink_interface_complete(data->iface, data->request);
 	return FALSE;
@@ -488,15 +568,45 @@ static int ffm_play(struct ffm_effect_data *data, int play)
 			data->poll_id = g_timeout_add(data->playback_time + 20,
 						ffm_playback_done, data);
 		}
-		N_DEBUG (LOG_CAT "Starting playback");
+		N_DEBUG (LOG_CAT "Starting playback %d", data->id);
 	} else {
-		N_DEBUG (LOG_CAT "Stopping playback");
+		ffm_playback_done(data);
+		N_DEBUG (LOG_CAT "Stopping playback %d", data->id);
 	}
 
-	if (ffmemless_play(data->id, ffm.dev_file, play))
-		return FALSE;
+	if (ffm.cache_effects) {
+		int16_t custom_data[CUSTOM_DATA_LEN] = {0, 0, 0};
+		if (play) {
+			data->cached_effect.id = -1;
+			if (data->cached_effect.type == FF_PERIODIC) {
+				custom_data[0] = data->customEffectId;
+				data->cached_effect.u.periodic.custom_data = custom_data;
+			}
+			if (ffmemless_upload_effect(&data->cached_effect, ffm.dev_file)) {
+				N_DEBUG (LOG_CAT "%d effect re-load failed", data->id);
+				if (data->poll_id) {
+					g_source_remove (data->poll_id);
+					data->poll_id = 0;
+				}
+				return FALSE;
+			} 
+		}
 
-	return TRUE;
+		if (ffmemless_play(data->cached_effect.id, ffm.dev_file, play))
+			return FALSE;
+		return TRUE;
+	} else {
+		if (ffmemless_play(data->id, ffm.dev_file, play))
+			return FALSE;
+		return TRUE;
+	}
+}
+
+static void ffm_sink_shutdown(NSinkInterface *iface)
+{
+	(void) iface;
+	g_hash_table_destroy(ffm.effects);
+	ffm_close_device(ffm.dev_file);
 }
 
 static int ffm_sink_initialize(NSinkInterface *iface)
@@ -510,6 +620,8 @@ static int ffm_sink_initialize(NSinkInterface *iface)
 
 	ffm.effects = ffm_new_effect_list(n_proplist_get_string(ffm.ngfd_props,
 							FFM_EFFECTLIST_KEY));
+	ffm.cache_effects = !g_strcmp0(n_proplist_get_string(ffm.ngfd_props, FFM_CACHE_EFFECTS_KEY), "true");
+	N_DEBUG (LOG_CAT "Caching effects: %d", ffm.cache_effects);
 
 	if (ffm_setup_default_effect(ffm.effects, ffm.dev_file)) {
 		N_ERROR (LOG_CAT "Could not load default fall-back effect");
@@ -531,16 +643,9 @@ static int ffm_sink_initialize(NSinkInterface *iface)
 	return TRUE;
 
 ffm_init_error2:
-	g_hash_table_destroy(ffm.effects);
-	ffm_close_device(ffm.dev_file);
+	ffm_sink_shutdown(iface);
 ffm_init_error1:
 	return FALSE;
-}
-static void ffm_sink_shutdown(NSinkInterface *iface)
-{
-	(void) iface;
-	g_hash_table_destroy(ffm.effects);
-	ffm_close_device(ffm.dev_file);
 }
 
 static int ffm_sink_can_handle(NSinkInterface *iface, NRequest *request)
@@ -570,11 +675,9 @@ static int ffm_sink_prepare(NSinkInterface *iface, NRequest *request)
 
 	/* creating copy of the data as we need to alter it for this event */
 	copy = g_new(struct ffm_effect_data, 1);
-	copy->id = data->id;
-	copy->repeat = data->repeat;
-	copy->iface = iface;
+	memcpy(copy, data, sizeof(struct ffm_effect_data));
 	copy->request = request;
-	copy->playback_time = data->playback_time;
+	copy->iface = iface;
 
 	repeat = n_proplist_get_bool (props, FFM_SOUND_REPEAT_KEY);
 	playback_time = n_proplist_get_uint (props, FFM_HAPTIC_DURATION_KEY);
@@ -585,7 +688,9 @@ static int ffm_sink_prepare(NSinkInterface *iface, NRequest *request)
 		 * keep repeating them until timer runs out and effect ends.
 		 */
 		copy->repeat = INT32_MAX; /* repeat to "infinity" */
-		copy->playback_time = playback_time;
+		if (!copy->playback_time && playback_time) {
+			copy->playback_time = playback_time;
+		};
 	}
 
 	N_DEBUG (LOG_CAT "prep effect %s, repeat %d times, duration of %d ms",
@@ -666,7 +771,7 @@ N_PLUGIN_LOAD(plugin)
 	};
 
 	/* Checking if there is a device, no point in loading plugin if not..*/
-	device_fd = ffmemless_evdev_file_search();
+	device_fd = ffmemless_evdev_file_search(ffm.features);
 	if (device_fd < 0) {
 		N_DEBUG (LOG_CAT "No force feedback device, stopping plugin");
 		return FALSE;


### PR DESCRIPTION
There are two changes in this PR for this ffmemless driver: https://github.com/b100dian/Xiaomi_Kernel_OpenSource/blob/tucana-q-oss/drivers/input/misc/drv260x_input.c#L1143

First, it only supports Constant effect or periodic effect with Custom waveform (see the link above, where the if/else is).
So this implements support for that. 

Second, the upload itself is mutating global state on the driver (see the link above) so you have to _always_ update before play.
This is implemented as a hardcoded define, but I can migrate it to a config setting.

Here's an example configuration with constant and custom periodic effect: https://github.com/sailfishos-on-tucana/droid-config-tucana/blob/master/sparse/usr/share/ngfd/plugins.d/51-ffmemless.ini#L57