### PR TITLE
Add support for QtFeedback compatible haptic effects

### DIFF
--- a/data/plugins.d/50-ffmemless.ini
+++ b/data/plugins.d/50-ffmemless.ini
@@ -20,7 +20,7 @@ system_effects_env = NGF_FFMEMLESS_SETTINGS
 
 
 # All effect names must be listed here, otherwise they don't get created
-supported_effects = touch;short;strong;long;notice;message;attention;alarm;ringtone
+supported_effects = touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
 
 # Setting up the effect parameters.
 # - The only mandatory parameter is _TYPE, if it's missing effect is not created
@@ -58,6 +58,51 @@ touch_TYPE = rumble
 touch_DURATION = 40
 touch_DELAY = 0
 touch_MAGNITUDE = 24000
+
+touch_weak_TYPE = rumble
+touch_weak_DURATION = 40
+touch_weak_DELAY = 0
+touch_weak_MAGNITUDE = 20000
+
+touch_strong_TYPE = rumble
+touch_strong_DURATION = 40
+touch_strong_DELAY = 0
+touch_strong_MAGNITUDE = 30000
+
+release_TYPE = rumble
+release_DURATION = 20
+release_DELAY = 0
+release_MAGNITUDE = 24000
+
+release_weak_TYPE = rumble
+release_weak_DURATION = 20
+release_weak_DELAY = 0
+release_weak_MAGNITUDE = 20000
+
+release_strong_TYPE = rumble
+release_strong_DURATION = 20
+release_strong_DELAY = 0
+release_strong_MAGNITUDE = 30000
+
+drag_start_TYPE = rumble
+drag_start_DURATION = 20
+drag_start_DELAY = 0
+drag_start_MAGNITUDE = 25000
+
+drag_fail_TYPE = rumble
+drag_fail_DURATION = 25
+drag_fail_DELAY = 0
+drag_fail_MAGNITUDE = 25000
+
+drag_boundary_TYPE = rumble
+drag_boundary_DURATION = 30
+drag_boundary_DELAY = 0
+drag_boundary_MAGNITUDE = 25000
+
+drag_end_TYPE = rumble
+drag_end_DURATION = 40
+drag_end_DELAY = 0
+drag_end_MAGNITUDE = 25000
 
 short_TYPE = rumble
 short_DURATION = 80

--- a/rpm/ngfd.spec
+++ b/rpm/ngfd.spec
@@ -4,7 +4,7 @@ Summary:    Non-graphic feedback service for sounds and other events
 Version:    1.2.5
 Release:    1
 License:    LGPLv2+
-URL:        https://git.sailfishos.org/mer-core/ngfd
+URL:        https://github.com/sailfishos/ngfd
 Source0:    %{name}-%{version}.tar.gz
 Source1:    ngfd.service
 Requires:   %{name}-settings

--- a/src/include/ngf/haptic.h
+++ b/src/include/ngf/haptic.h
@@ -62,15 +62,24 @@
  *
  * alarm and ringtone effects should repeat indefinitely.
  */
-#define N_HAPTIC_EFFECT_TOUCH     "touch"
-#define N_HAPTIC_EFFECT_SHORT     "short"
-#define N_HAPTIC_EFFECT_STRONG    "strong"
-#define N_HAPTIC_EFFECT_LONG      "long"
-#define N_HAPTIC_EFFECT_NOTICE    "notice"
-#define N_HAPTIC_EFFECT_MESSAGE   "message"
-#define N_HAPTIC_EFFECT_ATTENTION "attention"
-#define N_HAPTIC_EFFECT_ALARM     "alarm"
-#define N_HAPTIC_EFFECT_RINGTONE  "ringtone"
+#define N_HAPTIC_EFFECT_DRAG_START     "drag_start"
+#define N_HAPTIC_EFFECT_RELEASE_WEAK   "release_weak"
+#define N_HAPTIC_EFFECT_DRAG_FAIL      "drag_fail"
+#define N_HAPTIC_EFFECT_DRAG_BOUNDARY  "drag_boundary"
+#define N_HAPTIC_EFFECT_TOUCH_WEAK     "touch_weak"
+#define N_HAPTIC_EFFECT_DRAG_END       "drag_end"
+#define N_HAPTIC_EFFECT_RELEASE        "release"
+#define N_HAPTIC_EFFECT_TOUCH          "touch"
+#define N_HAPTIC_EFFECT_RELEASE_STRONG "release_strong"
+#define N_HAPTIC_EFFECT_TOUCH_STRONG   "touch_strong"
+#define N_HAPTIC_EFFECT_SHORT          "short"
+#define N_HAPTIC_EFFECT_STRONG         "strong"
+#define N_HAPTIC_EFFECT_LONG           "long"
+#define N_HAPTIC_EFFECT_NOTICE         "notice"
+#define N_HAPTIC_EFFECT_MESSAGE        "message"
+#define N_HAPTIC_EFFECT_ATTENTION      "attention"
+#define N_HAPTIC_EFFECT_ALARM          "alarm"
+#define N_HAPTIC_EFFECT_RINGTONE       "ringtone"
 
 /* Supported haptic classes */
 #define N_HAPTIC_CLASS_UNDEFINED  (0)

--- a/src/plugins/devicelock/plugin.c
+++ b/src/plugins/devicelock/plugin.c
@@ -22,7 +22,6 @@
 #include <ngf/plugin.h>
 #include <ngf/core-dbus.h>
 #include <dbus/dbus.h>
-#include <mce/dbus-names.h>
 
 #define LOG_CAT "devicelock: "
 #define DEVICE_LOCK_KEY "device_lock.state"

--- a/src/plugins/ffmemless/plugin.c
+++ b/src/plugins/ffmemless/plugin.c
@@ -38,6 +38,7 @@
 #define FFM_DEVFILE_KEY		"device_file_path"
 #define FFM_EFFECTLIST_KEY	"supported_effects"
 #define FFM_SOUND_REPEAT_KEY	"sound.repeat"
+#define FFM_HAPTIC_DURATION_KEY	"haptic.duration"
 #define FFM_MAX_PARAM_LEN	80
 
 #define NGF_DEFAULT_TYPE	FF_RUMBLE
@@ -554,6 +555,7 @@ static int ffm_sink_prepare(NSinkInterface *iface, NRequest *request)
 	const struct ffm_effect_data *data;
 	struct ffm_effect_data *copy;
 	gboolean repeat;
+	guint playback_time;
 	const gchar *key;
 
 	N_DEBUG (LOG_CAT "prepare");
@@ -575,12 +577,19 @@ static int ffm_sink_prepare(NSinkInterface *iface, NRequest *request)
 	copy->playback_time = data->playback_time;
 
 	repeat = n_proplist_get_bool (props, FFM_SOUND_REPEAT_KEY);
-	if (repeat) {
+	playback_time = n_proplist_get_uint (props, FFM_HAPTIC_DURATION_KEY);
+	if (repeat || playback_time) {
+		/*
+		 * If duration was not defined, it's zero and we don't report playback
+		 * done. Otherwise, as effects are already stored by the kernel we just
+		 * keep repeating them until timer runs out and effect ends.
+		 */
 		copy->repeat = INT32_MAX; /* repeat to "infinity" */
-		copy->playback_time = 0; /* don't report playback done */
+		copy->playback_time = playback_time;
 	}
 
-	N_DEBUG (LOG_CAT "prep effect %s, repeat %d times", key, copy->repeat);
+	N_DEBUG (LOG_CAT "prep effect %s, repeat %d times, duration of %d ms",
+			key, copy->repeat, copy->playback_time);
 
 	n_request_store_data(request, FFM_KEY, copy);
 	n_sink_interface_synchronize(iface, request);


### PR DESCRIPTION
Add more system-defined haptic effects to better support QtFeedback.

Add haptic.duration to ffmemless plugin. This allows to override duration of the effect.

Add configuration for ffmemless plugin for these new effects.

Also fix building without mce.