### PR TITLE
Revert "Configuration for the new effects in ffmemless"

### DIFF
--- a/data/plugins.d/50-ffmemless.ini
+++ b/data/plugins.d/50-ffmemless.ini
@@ -20,7 +20,7 @@ system_effects_env = NGF_FFMEMLESS_SETTINGS
 
 
 # All effect names must be listed here, otherwise they don't get created
-supported_effects = touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
+supported_effects = touch;short;strong;long;notice;message;attention;alarm;ringtone
 
 # Setting up the effect parameters.
 # - The only mandatory parameter is _TYPE, if it's missing effect is not created
@@ -58,51 +58,6 @@ touch_TYPE = rumble
 touch_DURATION = 40
 touch_DELAY = 0
 touch_MAGNITUDE = 24000
-
-touch_weak_TYPE = rumble
-touch_weak_DURATION = 40
-touch_weak_DELAY = 0
-touch_weak_MAGNITUDE = 20000
-
-touch_strong_TYPE = rumble
-touch_strong_DURATION = 40
-touch_strong_DELAY = 0
-touch_strong_MAGNITUDE = 30000
-
-release_TYPE = rumble
-release_DURATION = 20
-release_DELAY = 0
-release_MAGNITUDE = 24000
-
-release_weak_TYPE = rumble
-release_weak_DURATION = 20
-release_weak_DELAY = 0
-release_weak_MAGNITUDE = 20000
-
-release_strong_TYPE = rumble
-release_strong_DURATION = 20
-release_strong_DELAY = 0
-release_strong_MAGNITUDE = 30000
-
-drag_start_TYPE = rumble
-drag_start_DURATION = 20
-drag_start_DELAY = 0
-drag_start_MAGNITUDE = 25000
-
-drag_fail_TYPE = rumble
-drag_fail_DURATION = 25
-drag_fail_DELAY = 0
-drag_fail_MAGNITUDE = 25000
-
-drag_boundary_TYPE = rumble
-drag_boundary_DURATION = 30
-drag_boundary_DELAY = 0
-drag_boundary_MAGNITUDE = 25000
-
-drag_end_TYPE = rumble
-drag_end_DURATION = 40
-drag_end_DELAY = 0
-drag_end_MAGNITUDE = 25000
 
 short_TYPE = rumble
 short_DURATION = 80


### PR DESCRIPTION
This reverts commit fe30035500941284fa1d75cb5ca6bf927977c1cd.

The new list of effects are to big for the gpio device (vibramotor in PinePhone). The ngfd reports following error and segfaults afterwards:
```
Vibra upload effect: No space left on device
````


Detailed log:
```
[manjaro@manjaro-arm ngfd]$ gdb --args ngfd -vvv
GNU gdb (GDB) 11.1
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "aarch64-unknown-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ngfd...
(gdb) r
Starting program: /usr/bin/ngfd -vvv
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
[0.000] DEBUG: daemon: Starting.
[0.000] DEBUG: context: subscriber added for key 'call_state.mode'
[0.000] DEBUG: context: subscriber added for key 'profile.current.touchscreen.vibration.level'
[0.000] DEBUG: context: subscriber added for key 'profile.current.vibrating.alert.enabled'
[0.001] DEBUG: core: parsing configuration file '/usr/share/ngfd/ngfd.ini'
[0.001] DEBUG: core: new key type 'core.max_timeout' = INTEGER
[1.18446744073709550636] DEBUG: core: opened plugin 'dbus' (libngfd_dbus.so)
[1.18446744073709550649] DEBUG: core: new key type 'transform.allow_custom' = BOOLEAN
[1.18446744073709550649] DEBUG: core: + plugin parameter (transform): allow = media.audio media.vibra media.leds play.timeout play.mode audio dbus.event.id dbus.event.client tonegen.type tonegen.dbm0 tonegen.duration tonegen.pattern tonegen.value
[1.18446744073709550649] DEBUG: core: + plugin parameter (transform): transform.audio = sound.filename
[1.18446744073709550649] DEBUG: core: + plugin parameter (transform): general_tone_search_path = /usr/share/sounds
[1.18446744073709550649] DEBUG: core: opened plugin 'transform' (libngfd_transform.so)
[1.18446744073709550663] DEBUG: core: + plugin parameter (resource): media.audio = true
[1.18446744073709550663] DEBUG: core: + plugin parameter (resource): media.vibra = true
[1.18446744073709550663] DEBUG: core: + plugin parameter (resource): media.leds = true
[1.18446744073709550663] DEBUG: core: opened plugin 'resource' (libngfd_resource.so)
[1.18446744073709550684] DEBUG: core: + plugin parameter (profile): sound-levels = system.sound.level
[1.18446744073709550684] DEBUG: core: + plugin parameter (profile): system.sound.level = 0;50;75;100
[1.18446744073709550684] DEBUG: core: + plugin parameter (profile): search-path = /usr/share/sounds
[1.18446744073709550684] DEBUG: core: opened plugin 'profile' (libngfd_profile.so)
[1.18446744073709550704] DEBUG: core: + plugin parameter (streamrestore): role.x-meego-ringing-volume = profile.current.ringing.alert.volume
[1.18446744073709550704] DEBUG: core: + plugin parameter (streamrestore): role.x-meego-system-sound-level = profile.current.system.sound.level
[1.18446744073709550704] DEBUG: core: + plugin parameter (streamrestore): set.x-meego-full-volume = 100
[1.18446744073709550704] DEBUG: core: opened plugin 'stream-restore' (libngfd_streamrestore.so)
[1.18446744073709550819] DEBUG: core: opened plugin 'tonegen' (libngfd_tonegen.so)
[1.18446744073709550832] DEBUG: core: opened plugin 'mce' (libngfd_mce.so)
[1.18446744073709550863] DEBUG: core: opened plugin 'canberra' (libngfd_canberra.so)
[1.18446744073709551146] DEBUG: core: new key type 'sound.repeat' = BOOLEAN
[1.18446744073709551146] DEBUG: core: new key type 'sound.delay-startup' = INTEGER
[1.18446744073709551146] DEBUG: core: new key type 'sound.delay-stop' = INTEGER
[1.18446744073709551146] DEBUG: core: new key type 'sound.fade-pause' = INTEGER
[1.18446744073709551146] DEBUG: core: new key type 'sound.fade-resume' = INTEGER
[1.18446744073709551146] DEBUG: core: new key type 'sound.fade-stop' = INTEGER
[1.18446744073709551146] DEBUG: core: + plugin parameter (gst): ringtone_search_path = /usr/share/sounds/ring-tones/
[1.18446744073709551146] DEBUG: core: opened plugin 'gst' (libngfd_gst.so)
[1.18446744073709551154] DEBUG: core: opened plugin 'callstate' (libngfd_callstate.so)
[1.18446744073709551160] DEBUG: core: opened plugin 'route' (libngfd_route.so)
[1.18446744073709551171] DEBUG: core: + plugin parameter (ffmemless): system_effects_env = NGF_FFMEMLESS_SETTINGS
[1.18446744073709551171] DEBUG: core: + plugin parameter (ffmemless): supported_effects = touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
[1.18446744073709551171] DEBUG: core: + plugin parameter (ffmemless): touch_TYPE = rumble
[1.18446744073709551171] DEBUG: core: + plugin parameter (ffmemless): touch_DURATION = 40
[1.18446744073709551171] DEBUG: core: + plugin parameter (ffmemless): touch_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_MAGNITUDE = 24000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_weak_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_weak_DURATION = 40
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_weak_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_weak_MAGNITUDE = 20000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_strong_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_strong_DURATION = 40
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_strong_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): touch_strong_MAGNITUDE = 30000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_DURATION = 20
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_MAGNITUDE = 24000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_weak_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_weak_DURATION = 20
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_weak_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_weak_MAGNITUDE = 20000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_strong_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_strong_DURATION = 20
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_strong_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): release_strong_MAGNITUDE = 30000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_start_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_start_DURATION = 20
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_start_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_start_MAGNITUDE = 25000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_fail_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_fail_DURATION = 25
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_fail_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_fail_MAGNITUDE = 25000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_boundary_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_boundary_DURATION = 30
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_boundary_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_boundary_MAGNITUDE = 25000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_end_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_end_DURATION = 40
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_end_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): drag_end_MAGNITUDE = 25000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): short_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): short_DURATION = 80
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): short_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): short_MAGNITUDE = 24000
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): strong_TYPE = rumble
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): strong_DURATION = 80
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): strong_DELAY = 0
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): strong_MAGNITUDE = 65535
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): long_TYPE = periodic
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): long_WAVEFORM = sine
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): long_DURATION = 850
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): long_PERIOD = 150
[1.18446744073709551172] DEBUG: core: + plugin parameter (ffmemless): long_MAGNITUDE = 15383
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): long_ATTACK = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): long_ALEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): long_FADE = 180
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): long_FLEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_TYPE = periodic
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_WAVEFORM = sine
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_DURATION = 100
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_REPEAT = 2
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_DELAY = 500
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_PERIOD = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_MAGNITUDE = 47000
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_OFFSET = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_PHASE = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_DIRECTION = forward
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_ATTACK = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_ALEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_FADE = 5
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): notice_FLEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_TYPE = periodic
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_WAVEFORM = sine
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_DURATION = 240
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_REPEAT = 2
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_DELAY = 140
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_PERIOD = 50
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_MAGNITUDE = 27000
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_OFFSET = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_PHASE = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_DIRECTION = forward
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_ATTACK = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_ALEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_FADE = 80
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): message_FLEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_TYPE = periodic
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_WAVEFORM = sine
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_DURATION = 100
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_REPEAT = 3
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_DELAY = 100
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_PERIOD = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_MAGNITUDE = 37000
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_OFFSET = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_PHASE = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_DIRECTION = forward
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_ATTACK = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_ALEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_FADE = 5
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): attention_FLEVEL = 0
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): alarm_TYPE = periodic
[1.18446744073709551173] DEBUG: core: + plugin parameter (ffmemless): alarm_WAVEFORM = sine
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_DURATION = 4000
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_DELAY = 500
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_PERIOD = 100
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_MAGNITUDE = 8000
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_OFFSET = 0
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_PHASE = 0
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_DIRECTION = forward
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_ATTACK = 1000
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_ALEVEL = 0
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_FADE = 400
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): alarm_FLEVEL = 0
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_TYPE = periodic
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_WAVEFORM = sine
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_DURATION = 2400
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_DELAY = 400
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_PERIOD = 100
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_MAGNITUDE = 16383
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_OFFSET = 0
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_PHASE = 0
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_DIRECTION = forward
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_ATTACK = 500
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_ALEVEL = 2560
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_FADE = 300
[1.18446744073709551174] DEBUG: core: + plugin parameter (ffmemless): ringtone_FLEVEL = 4096
[1.18446744073709551174] DEBUG: core: opened plugin 'ffmemless' (libngfd_ffmemless.so)
[1.18446744073709551175] ERROR: core: unable to open plugin 'droid-vibrator'
[1.18446744073709551175] INFO: core: optional plugin droid-vibrator not opened.
[1.18446744073709551181] DEBUG: core: opened plugin 'devicelock' (libngfd_devicelock.so)
[1.18446744073709551182] DEBUG: core: processing event file '/usr/share/ngfd/events.d/accessory_connected.ini'
[1.18446744073709551182] DEBUG: event-list: new event 'accessory_connected'
[1.18446744073709551182] DEBUG: event-list: + default
[1.18446744073709551182] DEBUG: event-list: properties
[1.18446744073709551182] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_accessory_connected.wav (string)
[1.18446744073709551182] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551182] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551182] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551182] DEBUG: core: processing event file '/usr/share/ngfd/events.d/accessory_disconnected.ini'
[1.18446744073709551182] DEBUG: event-list: new event 'accessory_disconnected'
[1.18446744073709551182] DEBUG: event-list: + default
[1.18446744073709551182] DEBUG: event-list: properties
[1.18446744073709551182] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_accessory_disconnected.wav (string)
[1.18446744073709551182] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551183] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551183] DEBUG: core: processing event file '/usr/share/ngfd/events.d/battery_low.ini'
[1.18446744073709551183] DEBUG: event: new rule:
[1.18446744073709551183] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551183] DEBUG: event-list: new event 'battery_low'
[1.18446744073709551183] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551183] DEBUG: event-list: properties
[1.18446744073709551183] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_battery_low.wav (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551183] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551183] DEBUG: event-list: + ffmemless.effect = NGF_BATTERYLOW (string)
[1.18446744073709551183] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551183] DEBUG: event-list: new event 'battery_low'
[1.18446744073709551183] DEBUG: event-list: + default
[1.18446744073709551183] DEBUG: event-list: properties
[1.18446744073709551183] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_battery_low.wav (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551183] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551183] DEBUG: event-list: + ffmemless.effect = NGF_BATTERYLOW (string)
[1.18446744073709551183] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_battery_low.ivt (string)
[1.18446744073709551183] DEBUG: core: processing event file '/usr/share/ngfd/events.d/calendar.ini'
[1.18446744073709551183] DEBUG: event: new rule:
[1.18446744073709551183] DEBUG: event: + 'play.mode' == '*'
[1.18446744073709551183] DEBUG: event: new rule:
[1.18446744073709551183] DEBUG: event: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551183] DEBUG: event-list: new event 'calendar'
[1.18446744073709551183] DEBUG: event-list: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551183] DEBUG: event-list: + 'play.mode' == '*'
[1.18446744073709551183] DEBUG: event-list: properties
[1.18446744073709551183] DEBUG: event-list: + sound.filename = /usr/share/sounds/ring-tones/Beep.aac (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551183] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551183] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551183] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551183] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551183] DEBUG: context: subscriber added for key 'profile.current_profile'
[1.18446744073709551184] DEBUG: event: cached rule:
[1.18446744073709551184] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551184] DEBUG: event-list: new event 'calendar'
[1.18446744073709551184] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551184] DEBUG: event-list: properties
[1.18446744073709551184] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_in_call_beep.wav (string)
[1.18446744073709551184] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551184] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551184] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551184] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551184] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551184] DEBUG: event-list: new event 'calendar'
[1.18446744073709551184] DEBUG: event-list: + default
[1.18446744073709551184] DEBUG: event-list: properties
[1.18446744073709551184] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551184] DEBUG: event-list: + immvibe.profile.fallback = calendar.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551184] DEBUG: event-list: + sound.profile.fallback = calendar.alert.tone@fallback => sound.filename (string)
[1.18446744073709551184] DEBUG: event-list: + sound.profile = calendar.alert.tone => sound.filename (string)
[1.18446744073709551184] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551184] DEBUG: event-list: + immvibe.profile = calendar.alert.pattern => immvibe.filename (string)
[1.18446744073709551184] DEBUG: event-list: + sound.stream.event.id = alarm-clock-elapsed (string)
[1.18446744073709551184] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551184] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551184] DEBUG: core: processing event file '/usr/share/ngfd/events.d/charging_started.ini'
[1.18446744073709551184] DEBUG: event-list: new event 'charging_started'
[1.18446744073709551184] DEBUG: event-list: + default
[1.18446744073709551184] DEBUG: event-list: properties
[1.18446744073709551184] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551184] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551184] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551184] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551184] DEBUG: event-list: + immvibe.filename = filename:/usr/share/sounds/vibra/tct_charging_started.ivt (string)
[1.18446744073709551184] DEBUG: core: processing event file '/usr/share/ngfd/events.d/chat.ini'
[1.18446744073709551184] DEBUG: event: cached rule:
[1.18446744073709551184] DEBUG: event: + 'play.mode' == '*'
[1.18446744073709551184] DEBUG: event: cached rule:
[1.18446744073709551184] DEBUG: event: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551185] DEBUG: event-list: new event 'chat'
[1.18446744073709551185] DEBUG: event-list: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551185] DEBUG: event-list: + 'play.mode' == '*'
[1.18446744073709551185] DEBUG: event-list: properties
[1.18446744073709551185] DEBUG: event-list: + sound.filename = /usr/share/sounds/ring-tones/Beep.aac (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551185] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551185] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551185] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551185] DEBUG: event: cached rule:
[1.18446744073709551185] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551185] DEBUG: event-list: new event 'chat'
[1.18446744073709551185] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551185] DEBUG: event-list: properties
[1.18446744073709551185] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_default_beep.wav (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551185] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551185] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551185] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551185] DEBUG: event-list: new event 'chat'
[1.18446744073709551185] DEBUG: event-list: + default
[1.18446744073709551185] DEBUG: event-list: properties
[1.18446744073709551185] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551185] DEBUG: event-list: + immvibe.profile.fallback = im.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551185] DEBUG: event-list: + sound.profile.fallback = im.alert.tone@fallback => sound.filename (string)
[1.18446744073709551185] DEBUG: event-list: + sound.profile = im.alert.tone@general => sound.filename (string)
[1.18446744073709551185] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551185] DEBUG: event-list: + immvibe.profile = im.alert.pattern@general => immvibe.filename (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551185] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551185] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551185] DEBUG: core: processing event file '/usr/share/ngfd/events.d/chat_fg.ini'
[1.18446744073709551185] DEBUG: event-list: new event 'chat_fg'
[1.18446744073709551185] DEBUG: event-list: + default
[1.18446744073709551185] DEBUG: event-list: properties
[1.18446744073709551185] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_chat_fg.wav (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551185] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551185] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551185] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551186] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551186] DEBUG: core: processing event file '/usr/share/ngfd/events.d/clock.ini'
[1.18446744073709551186] DEBUG: event: cached rule:
[1.18446744073709551186] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551186] DEBUG: event-list: new event 'clock'
[1.18446744073709551186] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551186] DEBUG: event-list: properties
[1.18446744073709551186] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_in_call_beep.wav (string)
[1.18446744073709551186] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551186] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551186] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551186] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551186] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551186] DEBUG: event-list: new event 'clock'
[1.18446744073709551186] DEBUG: event-list: + default
[1.18446744073709551186] DEBUG: event-list: properties
[1.18446744073709551186] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-full-volume (string)
[1.18446744073709551186] DEBUG: event-list: + immvibe.profile.fallback = clock.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551186] DEBUG: event-list: + sound.profile.fallback = clock.alert.tone@fallback => sound.filename (string)
[1.18446744073709551186] DEBUG: event-list: + sound.profile = clock.alert.tone => sound.filename (string)
[1.18446744073709551186] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551186] DEBUG: event-list: + immvibe.profile = clock.alert.pattern => immvibe.filename (string)
[1.18446744073709551186] DEBUG: event-list: + sound.stream.event.id = alarm-clock-elapsed (string)
[1.18446744073709551186] DEBUG: event-list: + ffmemless.effect = NGF_CLOCK (string)
[1.18446744073709551186] DEBUG: event-list: + sound.repeat = TRUE (bool)
[1.18446744073709551186] DEBUG: event-list: + sound.volume = linear:10;100;15 (string)
[1.18446744073709551186] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551186] DEBUG: core: processing event file '/usr/share/ngfd/events.d/default.ini'
[1.18446744073709551186] DEBUG: event-list: new event 'default'
[1.18446744073709551186] DEBUG: event-list: + default
[1.18446744073709551186] DEBUG: event-list: properties
[1.18446744073709551186] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_default_beep.wav (string)
[1.18446744073709551186] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551186] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551187] DEBUG: core: processing event file '/usr/share/ngfd/events.d/email.ini'
[1.18446744073709551187] DEBUG: event: cached rule:
[1.18446744073709551187] DEBUG: event: + 'play.mode' == '*'
[1.18446744073709551187] DEBUG: event: cached rule:
[1.18446744073709551187] DEBUG: event: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551187] DEBUG: event-list: new event 'email'
[1.18446744073709551187] DEBUG: event-list: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551187] DEBUG: event-list: + 'play.mode' == '*'
[1.18446744073709551187] DEBUG: event-list: properties
[1.18446744073709551187] DEBUG: event-list: + sound.filename = /usr/share/sounds/ring-tones/Beep.aac (string)
[1.18446744073709551187] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551187] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551187] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551187] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551187] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551187] DEBUG: event: cached rule:
[1.18446744073709551187] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551187] DEBUG: event-list: new event 'email'
[1.18446744073709551187] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551187] DEBUG: event-list: properties
[1.18446744073709551187] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_default_beep.wav (string)
[1.18446744073709551187] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551187] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551187] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551187] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551187] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551187] DEBUG: event-list: new event 'email'
[1.18446744073709551187] DEBUG: event-list: + default
[1.18446744073709551187] DEBUG: event-list: properties
[1.18446744073709551187] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551187] DEBUG: event-list: + immvibe.profile.fallback = email.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551187] DEBUG: event-list: + sound.profile.fallback = email.alert.tone@fallback => sound.filename (string)
[1.18446744073709551187] DEBUG: event-list: + sound.profile = email.alert.tone@general => sound.filename (string)
[1.18446744073709551187] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551187] DEBUG: event-list: + immvibe.profile = email.alert.pattern@general => immvibe.filename (string)
[1.18446744073709551187] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551187] DEBUG: event-list: + ffmemless.effect = NGF_LONG (string)
[1.18446744073709551187] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551187] DEBUG: core: processing event file '/usr/share/ngfd/events.d/information_snd.ini'
[1.18446744073709551187] DEBUG: event-list: new event 'information_snd'
[1.18446744073709551187] DEBUG: event-list: + default
[1.18446744073709551188] DEBUG: event-list: properties
[1.18446744073709551188] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_information.wav (string)
[1.18446744073709551188] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551188] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551188] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551188] DEBUG: core: processing event file '/usr/share/ngfd/events.d/information_strong.ini'
[1.18446744073709551188] DEBUG: event-list: new event 'information_strong'
[1.18446744073709551188] DEBUG: event-list: + default
[1.18446744073709551188] DEBUG: event-list: properties
[1.18446744073709551188] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_information.wav (string)
[1.18446744073709551188] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551188] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551188] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551188] DEBUG: event-list: + ffmemless.effect = NGF_STRONG (string)
[1.18446744073709551188] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_information_strong.ivt (string)
[1.18446744073709551188] DEBUG: core: processing event file '/usr/share/ngfd/events.d/information_tacticon.ini'
[1.18446744073709551188] DEBUG: event-list: new event 'information_tacticon'
[1.18446744073709551188] DEBUG: event-list: + default
[1.18446744073709551188] DEBUG: event-list: properties
[1.18446744073709551188] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551188] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551188] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551188] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_information.ivt (string)
[1.18446744073709551188] DEBUG: core: processing event file '/usr/share/ngfd/events.d/notifier.ini'
[1.18446744073709551188] DEBUG: event-list: new event 'notifier'
[1.18446744073709551188] DEBUG: event-list: + default
[1.18446744073709551188] DEBUG: event-list: properties
[1.18446744073709551188] DEBUG: event-list: + mce.led_pattern = PatternCommunication (string)
[1.18446744073709551188] DEBUG: core: processing event file '/usr/share/ngfd/events.d/recharge_battery.ini'
[1.18446744073709551188] DEBUG: event: cached rule:
[1.18446744073709551188] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551188] DEBUG: event-list: new event 'recharge_battery'
[1.18446744073709551188] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551188] DEBUG: event-list: properties
[1.18446744073709551188] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_battery_low.wav (string)
[1.18446744073709551188] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551189] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551189] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551189] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551189] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551189] DEBUG: event-list: new event 'recharge_battery'
[1.18446744073709551189] DEBUG: event-list: + default
[1.18446744073709551189] DEBUG: event-list: properties
[1.18446744073709551189] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_recharge_battery.wav (string)
[1.18446744073709551189] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551189] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551189] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551189] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551189] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_recharge_battery.ivt (string)
[1.18446744073709551189] DEBUG: core: processing event file '/usr/share/ngfd/events.d/ringtone.ini'
[1.18446744073709551189] DEBUG: event: cached rule:
[1.18446744073709551189] DEBUG: event: + 'play.mode' == '*'
[1.18446744073709551189] DEBUG: event: cached rule:
[1.18446744073709551189] DEBUG: event: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551189] DEBUG: event-list: new event 'ringtone'
[1.18446744073709551189] DEBUG: event-list: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551189] DEBUG: event-list: + 'play.mode' == '*'
[1.18446744073709551189] DEBUG: event-list: properties
[1.18446744073709551189] DEBUG: event-list: + sound.filename = /usr/share/sounds/ring-tones/Beep.aac (string)
[1.18446744073709551189] DEBUG: event-list: + sound.stream.event.id = phone-incoming-call (string)
[1.18446744073709551189] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551189] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551189] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551189] DEBUG: event-list: + sound.repeat = FALSE (bool)
[1.18446744073709551189] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551189] DEBUG: event: cached rule:
[1.18446744073709551189] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551189] DEBUG: event-list: new event 'ringtone'
[1.18446744073709551189] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551189] DEBUG: event-list: properties
[1.18446744073709551189] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551189] DEBUG: event-list: + tonegen.dbm0 = -5 (string)
[1.18446744073709551189] DEBUG: event-list: + tonegen.pattern = wait (string)
[1.18446744073709551189] DEBUG: event-list: + tonegen.type = indicator (string)
[1.18446744073709551189] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551190] DEBUG: event-list: new event 'ringtone'
[1.18446744073709551190] DEBUG: event-list: + default
[1.18446744073709551190] DEBUG: event-list: properties
[1.18446744073709551190] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551190] DEBUG: event-list: + immvibe.profile.fallback = ringing.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551190] DEBUG: event-list: + ffmemless.effect = NGF_RINGTONE (string)
[1.18446744073709551190] DEBUG: event-list: + sound.repeat = TRUE (bool)
[1.18446744073709551190] DEBUG: event-list: + sound.profile = ringing.alert.tone => sound.filename (string)
[1.18446744073709551190] DEBUG: event-list: + immvibe.profile = ringing.alert.pattern => immvibe.filename (string)
[1.18446744073709551190] DEBUG: event-list: + sound.stream.event.id = phone-incoming-call (string)
[1.18446744073709551190] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551190] DEBUG: event-list: + sound.profile.fallback = ringing.alert.tone@fallback => sound.filename (string)
[1.18446744073709551190] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551190] DEBUG: core: processing event file '/usr/share/ngfd/events.d/sms.ini'
[1.18446744073709551190] DEBUG: event: cached rule:
[1.18446744073709551190] DEBUG: event: + 'play.mode' == '*'
[1.18446744073709551190] DEBUG: event: cached rule:
[1.18446744073709551190] DEBUG: event: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551190] DEBUG: event-list: new event 'sms'
[1.18446744073709551190] DEBUG: event-list: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551190] DEBUG: event-list: + 'play.mode' == '*'
[1.18446744073709551190] DEBUG: event-list: properties
[1.18446744073709551190] DEBUG: event-list: + sound.filename = /usr/share/sounds/ring-tones/Beep.aac (string)
[1.18446744073709551190] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551190] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551190] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551190] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551190] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551190] DEBUG: event: cached rule:
[1.18446744073709551190] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551190] DEBUG: event-list: new event 'sms'
[1.18446744073709551190] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551190] DEBUG: event-list: properties
[1.18446744073709551190] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_message_in_call.wav (string)
[1.18446744073709551190] DEBUG: event-list: + sound.stream.event.id = event-in-call (string)
[1.18446744073709551190] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551190] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551190] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551190] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551191] DEBUG: event-list: new event 'sms'
[1.18446744073709551191] DEBUG: event-list: + default
[1.18446744073709551191] DEBUG: event-list: properties
[1.18446744073709551191] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551191] DEBUG: event-list: + immvibe.profile.fallback = sms.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551191] DEBUG: event-list: + sound.profile.fallback = sms.alert.tone@fallback => sound.filename (string)
[1.18446744073709551191] DEBUG: event-list: + sound.profile = sms.alert.tone@general => sound.filename (string)
[1.18446744073709551191] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551191] DEBUG: event-list: + immvibe.profile = sms.alert.pattern@general => immvibe.filename (string)
[1.18446744073709551191] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551191] DEBUG: event-list: + ffmemless.effect = NGF_SMS (string)
[1.18446744073709551191] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551191] DEBUG: core: processing event file '/usr/share/ngfd/events.d/sms_fg.ini'
[1.18446744073709551191] DEBUG: event-list: new event 'sms_fg'
[1.18446744073709551191] DEBUG: event-list: + default
[1.18446744073709551191] DEBUG: event-list: properties
[1.18446744073709551191] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_message_fg.wav (string)
[1.18446744073709551191] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551191] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551191] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551191] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551191] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551191] DEBUG: core: processing event file '/usr/share/ngfd/events.d/voip_ringtone.ini'
[1.18446744073709551191] DEBUG: event: cached rule:
[1.18446744073709551191] DEBUG: event: + 'play.mode' == '*'
[1.18446744073709551191] DEBUG: event: cached rule:
[1.18446744073709551191] DEBUG: event: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551191] DEBUG: event-list: new event 'voip_ringtone'
[1.18446744073709551191] DEBUG: event-list: + context@'profile.current_profile' == 'meeting (string)'
[1.18446744073709551191] DEBUG: event-list: + 'play.mode' == '*'
[1.18446744073709551191] DEBUG: event-list: properties
[1.18446744073709551191] DEBUG: event-list: + ffmemless.effect = NGF_SHORT (string)
[1.18446744073709551191] DEBUG: event-list: + sound.stream.event.id = phone-incoming-call (string)
[1.18446744073709551191] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551191] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551191] DEBUG: event-list: + sound.repeat = FALSE (bool)
[1.18446744073709551191] DEBUG: event-list: + sound.profile = voip.alert.tone => sound.filename (string)
[1.18446744073709551191] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_small_alert.ivt (string)
[1.18446744073709551191] DEBUG: event: cached rule:
[1.18446744073709551192] DEBUG: event: + 'play.mode' == 'short (string)'
[1.18446744073709551192] DEBUG: event-list: new event 'voip_ringtone'
[1.18446744073709551192] DEBUG: event-list: + 'play.mode' == 'short (string)'
[1.18446744073709551192] DEBUG: event-list: properties
[1.18446744073709551192] DEBUG: event-list: + tonegen.pattern = 79 (string)
[1.18446744073709551192] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551192] DEBUG: event-list: + tonegen.volume = -5 (string)
[1.18446744073709551192] DEBUG: event-list: new event 'voip_ringtone'
[1.18446744073709551192] DEBUG: event-list: + default
[1.18446744073709551192] DEBUG: event-list: properties
[1.18446744073709551192] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-ringing-volume (string)
[1.18446744073709551192] DEBUG: event-list: + immvibe.profile.fallback = ringing.alert.pattern@fallback => immvibe.filename (string)
[1.18446744073709551192] DEBUG: event-list: + ffmemless.effect = NGF_RINGTONE (string)
[1.18446744073709551192] DEBUG: event-list: + sound.repeat = TRUE (bool)
[1.18446744073709551192] DEBUG: event-list: + sound.profile = voip.alert.tone => sound.filename (string)
[1.18446744073709551192] DEBUG: event-list: + immvibe.profile = ringing.alert.pattern => immvibe.filename (string)
[1.18446744073709551192] DEBUG: event-list: + sound.stream.event.id = phone-incoming-call (string)
[1.18446744073709551192] DEBUG: event-list: + immvibe.lookup = true (string)
[1.18446744073709551192] DEBUG: event-list: + sound.profile.fallback = voip.alert.tone@fallback => sound.filename (string)
[1.18446744073709551192] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551192] DEBUG: core: processing event file '/usr/share/ngfd/events.d/warning_snd.ini'
[1.18446744073709551192] DEBUG: event-list: new event 'warning_snd'
[1.18446744073709551192] DEBUG: event-list: + default
[1.18446744073709551192] DEBUG: event-list: properties
[1.18446744073709551192] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_warning.wav (string)
[1.18446744073709551192] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551192] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551192] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551192] DEBUG: core: processing event file '/usr/share/ngfd/events.d/warning_strong.ini'
[1.18446744073709551192] DEBUG: event-list: new event 'warning_strong'
[1.18446744073709551192] DEBUG: event-list: + default
[1.18446744073709551192] DEBUG: event-list: properties
[1.18446744073709551192] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_information.wav (string)
[1.18446744073709551192] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551192] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551192] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551192] DEBUG: event-list: + ffmemless.effect = NGF_STRONG (string)
[1.18446744073709551192] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_warning_strong.ivt (string)
[1.18446744073709551192] DEBUG: core: processing event file '/usr/share/ngfd/events.d/warning_tacticon.ini'
[1.18446744073709551193] DEBUG: event-list: new event 'warning_tacticon'
[1.18446744073709551193] DEBUG: event-list: + default
[1.18446744073709551193] DEBUG: event-list: properties
[1.18446744073709551193] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551193] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551193] DEBUG: event-list: + ffmemless.effect = NGF_LONG (string)
[1.18446744073709551193] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_warning.ivt (string)
[1.18446744073709551193] DEBUG: core: processing event file '/usr/share/ngfd/events.d/wrong_charger.ini'
[1.18446744073709551193] DEBUG: event-list: new event 'wrong_charger'
[1.18446744073709551193] DEBUG: event-list: + default
[1.18446744073709551193] DEBUG: event-list: properties
[1.18446744073709551193] DEBUG: event-list: + sound.filename = /usr/share/sounds/ui-tones/snd_warning.wav (string)
[1.18446744073709551193] DEBUG: event-list: + sound.stream.event.id = message-new-email (string)
[1.18446744073709551193] DEBUG: event-list: + sound.stream.module-stream-restore.id = x-meego-system-sound-level (string)
[1.18446744073709551193] DEBUG: event-list: + haptic.type = alarm (string)
[1.18446744073709551193] DEBUG: event-list: + ffmemless.effect = NGF_LONG (string)
[1.18446744073709551193] DEBUG: event-list: + immvibe.filename = /usr/share/sounds/vibra/tct_warning.ivt (string)
[1.18446744073709551193] INFO: core: configuration dir '/etc/ngfd/events.d' doesn't exist.
[1.18446744073709551193] DEBUG: core: input interface 'dbus' registered
[1.18446744073709551193] DEBUG: transform: allowed key 'media.audio'
[1.18446744073709551193] DEBUG: transform: allowed key 'media.vibra'
[1.18446744073709551193] DEBUG: transform: allowed key 'media.leds'
[1.18446744073709551193] DEBUG: transform: allowed key 'play.timeout'
[1.18446744073709551193] DEBUG: transform: allowed key 'play.mode'
[1.18446744073709551193] DEBUG: transform: allowed key 'audio'
[1.18446744073709551193] DEBUG: transform: allowed key 'dbus.event.id'
[1.18446744073709551193] DEBUG: transform: allowed key 'dbus.event.client'
[1.18446744073709551193] DEBUG: transform: allowed key 'tonegen.type'
[1.18446744073709551193] DEBUG: transform: allowed key 'tonegen.dbm0'
[1.18446744073709551193] DEBUG: transform: allowed key 'tonegen.duration'
[1.18446744073709551193] DEBUG: transform: allowed key 'tonegen.pattern'
[1.18446744073709551193] DEBUG: transform: allowed key 'tonegen.value'
[1.18446744073709551193] DEBUG: transform: will transform key 'audio' to 'sound.filename'
[1.18446744073709551193] DEBUG: core: 0x0xfffff77252c0 connected to hook 'new_request'
[1.18446744073709551193] DEBUG: core: 0x0xfffff7711ea0 connected to hook 'filter_sinks'
[1.18446744073709551193] DEBUG: profile: searching profile entries from event 'accessory_connected'
[1.18446744073709551193] DEBUG: profile: searching profile entries from event 'accessory_disconnected'
[1.18446744073709551193] DEBUG: profile: searching profile entries from event 'battery_low'
[1.18446744073709551193] DEBUG: profile: searching profile entries from event 'battery_low'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'calendar'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'calendar'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'calendar'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'calendar.alert.pattern', profile 'fallback' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'calendar.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'calendar.alert.tone', profile '(null)' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: new unique transform key 'sound.profile'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'calendar.alert.pattern', profile '(null)' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: new unique transform key 'immvibe.profile'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'charging_started'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'chat'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'chat'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'chat'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'im.alert.pattern', profile 'fallback' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'im.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'im.alert.tone', profile 'general' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'im.alert.pattern', profile 'general' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'chat_fg'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'clock'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'clock'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'clock.alert.pattern', profile 'fallback' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'clock.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'clock.alert.tone', profile '(null)' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'clock.alert.pattern', profile '(null)' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'default'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'email'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'email'
[1.18446744073709551194] DEBUG: profile: searching profile entries from event 'email'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'email.alert.pattern', profile 'fallback' and target 'immvibe.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'email.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551194] DEBUG: profile: new profile entry with key 'email.alert.tone', profile 'general' and target 'sound.filename'
[1.18446744073709551194] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'email.alert.pattern', profile 'general' and target 'immvibe.filename'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'information_snd'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'information_strong'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'information_tacticon'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'notifier'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'recharge_battery'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'recharge_battery'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'ringtone'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'ringtone'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'ringtone'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'ringing.alert.pattern', profile 'fallback' and target 'immvibe.filename'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'ringing.alert.tone', profile '(null)' and target 'sound.filename'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'ringing.alert.pattern', profile '(null)' and target 'immvibe.filename'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'ringing.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'sms'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'sms'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'sms'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'sms.alert.pattern', profile 'fallback' and target 'immvibe.filename'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'sms.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'sms.alert.tone', profile 'general' and target 'sound.filename'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'sms.alert.pattern', profile 'general' and target 'immvibe.filename'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'sms_fg'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'voip_ringtone'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'voip.alert.tone', profile '(null)' and target 'sound.filename'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'voip_ringtone'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'voip_ringtone'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'immvibe.profile.fallback'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'immvibe.profile'
[1.18446744073709551195] DEBUG: profile: possible profile key entry 'sound.profile.fallback'
[1.18446744073709551195] DEBUG: profile: new profile entry with key 'voip.alert.tone', profile 'fallback' and target 'sound.filename'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'warning_snd'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'warning_strong'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'warning_tacticon'
[1.18446744073709551195] DEBUG: profile: searching profile entries from event 'wrong_charger'
[1.18446744073709551195] DEBUG: core: 0x0xfffff76fe4a0 connected to hook 'transform_properties'
[1.18446744073709551195] DEBUG: profile: adding profile convert entry 'system.sound.level' with 4 sound levels
[1.18446744073709551198] DEBUG: profile: Connected to DBus session bus.
[1.18446744073709551200] DEBUG: context: broadcasting value change for 'profile.current_profile': <null> -> general (string)
[1.18446744073709551200] DEBUG: profile: current profile set to 'general'
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.calendar.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.calendar.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.calendar.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-2.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.calendar.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-2.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.clock.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.clock.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.clock.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-3.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.clock.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-3.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.clock.alert.volume': <null> -> 100 (int)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.clock.alert.volume': <null> -> 100 (int)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.email.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.email.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.email.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.email.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.im.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.im.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.im.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.im.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.general.im_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551202] DEBUG: context: broadcasting value change for 'profile.current.im_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.general.im_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.current.im_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.general.keypad.sound.level': <null> -> <unknown value>
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.current.keypad.sound.level': <null> -> <unknown value>
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.general.ringing.alert.enabled': <null> -> On (string)
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.current.ringing.alert.enabled': <null> -> On (string)
[1.18446744073709551203] DEBUG: context: broadcasting value change for 'profile.general.ringing.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.current.ringing.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.general.ringing.alert.type': <null> -> Ringing (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.current.ringing.alert.type': <null> -> Ringing (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.general.ringing.alert.volume': <null> -> 80 (int)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.current.ringing.alert.volume': <null> -> 80 (int)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.general.sms.alert.enabled': <null> -> On (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.current.sms.alert.enabled': <null> -> On (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.general.sms.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.current.sms.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.general.sms_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.current.sms_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551204] DEBUG: context: broadcasting value change for 'profile.general.sms_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.sms_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.general.system.sound.level': <null> -> 50 (int)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.system.sound.level': <null> -> 50 (int)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.general.touchscreen.sound.level': <null> -> <unknown value>
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.touchscreen.sound.level': <null> -> <unknown value>
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.general.touchscreen.vibration.level': <null> -> 1 (int)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.touchscreen.vibration.level': <null> -> 1 (int)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.general.vibrating.alert.enabled': <null> -> TRUE (bool)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.vibrating.alert.enabled': <null> -> TRUE (bool)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.general.voip.alert.enabled': <null> -> On (string)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.voip.alert.enabled': <null> -> On (string)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.general.voip.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551205] DEBUG: context: broadcasting value change for 'profile.current.voip.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.calendar.alert.enabled': <null> -> On (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.calendar.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-2.ogg (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.clock.alert.enabled': <null> -> On (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.clock.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-3.ogg (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.clock.alert.volume': <null> -> 100 (int)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.email.alert.enabled': <null> -> On (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.email.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.im.alert.enabled': <null> -> On (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.im.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551207] DEBUG: context: broadcasting value change for 'profile.meeting.im_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.im_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.keypad.sound.level': <null> -> <unknown value>
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.ringing.alert.enabled': <null> -> On (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.ringing.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.ringing.alert.type': <null> -> Ringing (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.ringing.alert.volume': <null> -> 80 (int)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.sms.alert.enabled': <null> -> On (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.sms.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.sms_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.sms_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.system.sound.level': <null> -> 50 (int)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.touchscreen.sound.level': <null> -> <unknown value>
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.touchscreen.vibration.level': <null> -> 1 (int)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.vibrating.alert.enabled': <null> -> TRUE (bool)
[1.18446744073709551208] DEBUG: context: broadcasting value change for 'profile.meeting.voip.alert.enabled': <null> -> On (string)
[1.18446744073709551209] DEBUG: context: broadcasting value change for 'profile.meeting.voip.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.calendar.alert.enabled': <null> -> On (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.calendar.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-2.ogg (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.clock.alert.enabled': <null> -> On (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.clock.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-3.ogg (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.clock.alert.volume': <null> -> 100 (int)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.email.alert.enabled': <null> -> On (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.email.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.im.alert.enabled': <null> -> On (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.im.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551210] DEBUG: context: broadcasting value change for 'profile.outdoors.im_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.im_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.keypad.sound.level': <null> -> <unknown value>
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.ringing.alert.enabled': <null> -> On (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.ringing.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.ringing.alert.type': <null> -> Ringing (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.ringing.alert.volume': <null> -> 80 (int)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.sms.alert.enabled': <null> -> On (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.sms.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.sms_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.sms_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551211] DEBUG: context: broadcasting value change for 'profile.outdoors.system.sound.level': <null> -> 50 (int)
[1.18446744073709551212] DEBUG: context: broadcasting value change for 'profile.outdoors.touchscreen.sound.level': <null> -> <unknown value>
[1.18446744073709551212] DEBUG: context: broadcasting value change for 'profile.outdoors.touchscreen.vibration.level': <null> -> 1 (int)
[1.18446744073709551212] DEBUG: context: broadcasting value change for 'profile.outdoors.vibrating.alert.enabled': <null> -> TRUE (bool)
[1.18446744073709551212] DEBUG: context: broadcasting value change for 'profile.outdoors.voip.alert.enabled': <null> -> On (string)
[1.18446744073709551212] DEBUG: context: broadcasting value change for 'profile.outdoors.voip.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.calendar.alert.enabled': <null> -> Off (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.calendar.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-2.ogg (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.clock.alert.enabled': <null> -> On (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.clock.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-3.ogg (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.clock.alert.volume': <null> -> 100 (int)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.email.alert.enabled': <null> -> Off (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.email.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.im.alert.enabled': <null> -> Off (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.im.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551213] DEBUG: context: broadcasting value change for 'profile.silent.im_fg.alert.enabled': <null> -> Off (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.im_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.keypad.sound.level': <null> -> <unknown value>
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.ringing.alert.enabled': <null> -> On (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.ringing.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.ringing.alert.type': <null> -> Silent (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.ringing.alert.volume': <null> -> 0 (int)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.sms.alert.enabled': <null> -> Off (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.sms.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551214] DEBUG: context: broadcasting value change for 'profile.silent.sms_fg.alert.enabled': <null> -> Off (string)
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.sms_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.system.sound.level': <null> -> 0 (int)
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.touchscreen.sound.level': <null> -> <unknown value>
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.touchscreen.vibration.level': <null> -> 1 (int)
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.vibrating.alert.enabled': <null> -> TRUE (bool)
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.voip.alert.enabled': <null> -> Off (string)
[1.18446744073709551215] DEBUG: context: broadcasting value change for 'profile.silent.voip.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.calendar.alert.enabled': <null> -> On (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.calendar.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-2.ogg (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.clock.alert.enabled': <null> -> On (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.clock.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-3.ogg (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.clock.alert.volume': <null> -> 100 (int)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.email.alert.enabled': <null> -> On (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.email.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.im.alert.enabled': <null> -> On (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.im.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551216] DEBUG: context: broadcasting value change for 'profile.fallback.im_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.im_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.keypad.sound.level': <null> -> <unknown value>
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.ringing.alert.enabled': <null> -> On (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.ringing.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.ringing.alert.type': <null> -> Ringing (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.ringing.alert.volume': <null> -> 80 (int)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.sms.alert.enabled': <null> -> On (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.sms.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/alert-1.ogg (string)
[1.18446744073709551217] DEBUG: context: broadcasting value change for 'profile.fallback.sms_fg.alert.enabled': <null> -> On (string)
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.sms_fg.alert.tone': <null> -> /usr/share/sounds/jolla-ambient/stereo/alert-1.ogg (string)
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.system.sound.level': <null> -> 50 (int)
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.touchscreen.sound.level': <null> -> <unknown value>
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.touchscreen.vibration.level': <null> -> 1 (int)
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.vibrating.alert.enabled': <null> -> TRUE (bool)
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.voip.alert.enabled': <null> -> On (string)
[1.18446744073709551218] DEBUG: context: broadcasting value change for 'profile.fallback.voip.alert.tone': <null> -> /usr/share/sounds/glacier/stereo/ring-1.ogg (string)
[1.18446744073709551218] DEBUG: stream-restore: new role entry 'x-meego-system-sound-level'
[1.18446744073709551218] DEBUG: context: subscriber added for key 'profile.current.system.sound.level'
[1.18446744073709551218] DEBUG: stream-restore: new role entry 'x-meego-ringing-volume'
[1.18446744073709551218] DEBUG: context: subscriber added for key 'profile.current.ringing.alert.volume'
[1.18446744073709551219] DEBUG: stream-restore: queueing op type: SET role: 'x-meego-full-volume' volume: '100'
[1.18446744073709551219] DEBUG: core: 0x0xfffff76e5224 connected to hook 'init_done'
[1.18446744073709551219] DEBUG: context: subscriber added for key 'route.output.type'
[1.18446744073709551219] DEBUG: context: broadcasting value change for 'media.state': <null> -> inactive (string)
[1.18446744073709551219] DEBUG: core: sink interface 'tonegen' registered
[1.18446744073709551222] DEBUG: core-dbus: get initial system bus
[1.18446744073709551222] DEBUG: core-dbus: new match 'type='signal',interface='com.nokia.mce.signal',path='/com/nokia/mce/signal',member='led_pattern_deactivated_ind''
[1.18446744073709551222] DEBUG: core-dbus: add match callback 'type='signal',interface='com.nokia.mce.signal',path='/com/nokia/mce/signal',member='led_pattern_deactivated_ind'' -> 1 : 0xfffff76925b0
[1.18446744073709551222] DEBUG: core: sink interface 'mce' registered
[1.18446744073709551222] DEBUG: canberra: plugin load
[1.18446744073709551222] DEBUG: core: sink interface 'canberra' registered
[1.18446744073709551222] DEBUG: core: sink interface 'gst' registered
[1.18446744073709551222] DEBUG: core: 0x0xfffff71b2730 connected to hook 'init_done'
[1.18446744073709551222] DEBUG: core-dbus: get cached system bus
[1.18446744073709551222] DEBUG: core-dbus: new match 'type='signal',interface='com.nokia.mce.signal',path='/com/nokia/mce/signal',member='sig_call_state_ind''
[1.18446744073709551222] DEBUG: core-dbus: add match callback 'type='signal',interface='com.nokia.mce.signal',path='/com/nokia/mce/signal',member='sig_call_state_ind'' -> 2 : 0xfffff7113e30
[1.18446744073709551222] DEBUG: core-dbus: get cached system bus
[1.18446744073709551223] DEBUG: core-dbus: do async call com.nokia.mce /com/nokia/mce/request com.nokia.mce.request.get_call_state
[1.18446744073709551223] DEBUG: core-dbus: get cached system bus
[1.18446744073709551223] DEBUG: core-dbus: new match 'type='signal',interface='org.nemomobile.Route.Manager',path='/org/nemomobile/Route/Manager',member='AudioRouteChanged''
[1.18446744073709551223] DEBUG: core-dbus: add match callback 'type='signal',interface='org.nemomobile.Route.Manager',path='/org/nemomobile/Route/Manager',member='AudioRouteChanged'' -> 3 : 0xfffff64e6ce0
[1.18446744073709551223] DEBUG: core-dbus: get cached system bus
[1.18446744073709551223] DEBUG: core-dbus: do async call org.nemomobile.Route.Manager /org/nemomobile/Route/Manager org.nemomobile.Route.Manager.ActiveRoutes
[1.18446744073709551223] DEBUG: ffmemless: plugin load
[1.18446744073709551277] DEBUG: ffmemless: NULL file_name parameter, cannot read props
[1.18446744073709551277] DEBUG: proplist: touch_weak_TYPE = rumble (string)
[1.18446744073709551277] DEBUG: proplist: alarm_DELAY = 500 (string)
[1.18446744073709551277] DEBUG: proplist: touch_strong_DURATION = 40 (string)
[1.18446744073709551277] DEBUG: proplist: drag_fail_MAGNITUDE = 25000 (string)
[1.18446744073709551277] DEBUG: proplist: message_WAVEFORM = sine (string)
[1.18446744073709551277] DEBUG: proplist: message_PERIOD = 50 (string)
[1.18446744073709551277] DEBUG: proplist: drag_boundary_DELAY = 0 (string)
[1.18446744073709551277] DEBUG: proplist: alarm_ATTACK = 1000 (string)
[1.18446744073709551277] DEBUG: proplist: drag_fail_TYPE = rumble (string)
[1.18446744073709551277] DEBUG: proplist: notice_TYPE = periodic (string)
[1.18446744073709551277] DEBUG: proplist: message_OFFSET = 0 (string)
[1.18446744073709551277] DEBUG: proplist: alarm_PERIOD = 100 (string)
[1.18446744073709551277] DEBUG: proplist: attention_PERIOD = 0 (string)
[1.18446744073709551277] DEBUG: proplist: strong_MAGNITUDE = 65535 (string)
[1.18446744073709551277] DEBUG: proplist: short_TYPE = rumble (string)
[1.18446744073709551277] DEBUG: proplist: drag_start_TYPE = rumble (string)
[1.18446744073709551277] DEBUG: proplist: short_DURATION = 80 (string)
[1.18446744073709551277] DEBUG: proplist: drag_boundary_TYPE = rumble (string)
[1.18446744073709551277] DEBUG: proplist: message_FLEVEL = 0 (string)
[1.18446744073709551277] DEBUG: proplist: ringtone_ATTACK = 500 (string)
[1.18446744073709551277] DEBUG: proplist: notice_ATTACK = 0 (string)
[1.18446744073709551277] DEBUG: proplist: message_TYPE = periodic (string)
[1.18446744073709551277] DEBUG: proplist: alarm_OFFSET = 0 (string)
[1.18446744073709551277] DEBUG: proplist: release_strong_DELAY = 0 (string)
[1.18446744073709551277] DEBUG: proplist: ringtone_WAVEFORM = sine (string)
[1.18446744073709551277] DEBUG: proplist: ringtone_DURATION = 2400 (string)
[1.18446744073709551277] DEBUG: proplist: attention_OFFSET = 0 (string)
[1.18446744073709551277] DEBUG: proplist: alarm_ALEVEL = 0 (string)
[1.18446744073709551277] DEBUG: proplist: short_DELAY = 0 (string)
[1.18446744073709551277] DEBUG: proplist: alarm_DURATION = 4000 (string)
[1.18446744073709551277] DEBUG: proplist: ringtone_DIRECTION = forward (string)
[1.18446744073709551277] DEBUG: proplist: release_MAGNITUDE = 24000 (string)
[1.18446744073709551277] DEBUG: proplist: message_DIRECTION = forward (string)
[1.18446744073709551277] DEBUG: proplist: alarm_FLEVEL = 0 (string)
[1.18446744073709551277] DEBUG: proplist: attention_WAVEFORM = sine (string)
[1.18446744073709551277] DEBUG: proplist: attention_DURATION = 100 (string)
[1.18446744073709551277] DEBUG: proplist: ringtone_PHASE = 0 (string)
[1.18446744073709551277] DEBUG: proplist: notice_REPEAT = 2 (string)
[1.18446744073709551277] DEBUG: proplist: system_effects_env = NGF_FFMEMLESS_SETTINGS (string)
[1.18446744073709551277] DEBUG: proplist: attention_FLEVEL = 0 (string)
[1.18446744073709551277] DEBUG: proplist: attention_PHASE = 0 (string)
[1.18446744073709551277] DEBUG: proplist: notice_MAGNITUDE = 47000 (string)
[1.18446744073709551278] DEBUG: proplist: attention_DIRECTION = forward (string)
[1.18446744073709551278] DEBUG: proplist: attention_TYPE = periodic (string)
[1.18446744073709551278] DEBUG: proplist: drag_start_MAGNITUDE = 25000 (string)
[1.18446744073709551278] DEBUG: proplist: long_DURATION = 850 (string)
[1.18446744073709551278] DEBUG: proplist: drag_start_DELAY = 0 (string)
[1.18446744073709551278] DEBUG: proplist: supported_effects = touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone (string)
[1.18446744073709551278] DEBUG: proplist: touch_weak_DURATION = 40 (string)
[1.18446744073709551278] DEBUG: proplist: release_weak_DURATION = 20 (string)
[1.18446744073709551278] DEBUG: proplist: long_PERIOD = 150 (string)
[1.18446744073709551278] DEBUG: proplist: notice_FADE = 5 (string)
[1.18446744073709551278] DEBUG: proplist: alarm_DIRECTION = forward (string)
[1.18446744073709551278] DEBUG: proplist: drag_end_DURATION = 40 (string)
[1.18446744073709551278] DEBUG: proplist: drag_fail_DURATION = 25 (string)
[1.18446744073709551278] DEBUG: proplist: notice_ALEVEL = 0 (string)
[1.18446744073709551278] DEBUG: proplist: touch_strong_MAGNITUDE = 30000 (string)
[1.18446744073709551278] DEBUG: proplist: notice_DELAY = 500 (string)
[1.18446744073709551278] DEBUG: proplist: ringtone_ALEVEL = 2560 (string)
[1.18446744073709551278] DEBUG: proplist: release_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: drag_boundary_MAGNITUDE = 25000 (string)
[1.18446744073709551278] DEBUG: proplist: notice_DURATION = 100 (string)
[1.18446744073709551278] DEBUG: proplist: long_TYPE = periodic (string)
[1.18446744073709551278] DEBUG: proplist: long_MAGNITUDE = 15383 (string)
[1.18446744073709551278] DEBUG: proplist: alarm_TYPE = periodic (string)
[1.18446744073709551278] DEBUG: proplist: strong_DELAY = 0 (string)
[1.18446744073709551278] DEBUG: proplist: message_FADE = 80 (string)
[1.18446744073709551278] DEBUG: proplist: long_FLEVEL = 0 (string)
[1.18446744073709551278] DEBUG: proplist: drag_end_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: short_MAGNITUDE = 24000 (string)
[1.18446744073709551278] DEBUG: proplist: message_ATTACK = 0 (string)
[1.18446744073709551278] DEBUG: proplist: message_PHASE = 0 (string)
[1.18446744073709551278] DEBUG: proplist: ringtone_TYPE = periodic (string)
[1.18446744073709551278] DEBUG: proplist: touch_strong_DELAY = 0 (string)
[1.18446744073709551278] DEBUG: proplist: touch_weak_DELAY = 0 (string)
[1.18446744073709551278] DEBUG: proplist: touch_MAGNITUDE = 24000 (string)
[1.18446744073709551278] DEBUG: proplist: alarm_PHASE = 0 (string)
[1.18446744073709551278] DEBUG: proplist: message_REPEAT = 2 (string)
[1.18446744073709551278] DEBUG: proplist: attention_FADE = 5 (string)
[1.18446744073709551278] DEBUG: proplist: attention_ATTACK = 0 (string)
[1.18446744073709551278] DEBUG: proplist: message_DURATION = 240 (string)
[1.18446744073709551278] DEBUG: proplist: release_DELAY = 0 (string)
[1.18446744073709551278] DEBUG: proplist: release_weak_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: attention_REPEAT = 3 (string)
[1.18446744073709551278] DEBUG: proplist: message_ALEVEL = 0 (string)
[1.18446744073709551278] DEBUG: proplist: touch_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: strong_DURATION = 80 (string)
[1.18446744073709551278] DEBUG: proplist: release_strong_MAGNITUDE = 30000 (string)
[1.18446744073709551278] DEBUG: proplist: long_FADE = 180 (string)
[1.18446744073709551278] DEBUG: proplist: strong_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: alarm_FADE = 400 (string)
[1.18446744073709551278] DEBUG: proplist: drag_start_DURATION = 20 (string)
[1.18446744073709551278] DEBUG: proplist: ringtone_DELAY = 400 (string)
[1.18446744073709551278] DEBUG: proplist: release_strong_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: notice_DIRECTION = forward (string)
[1.18446744073709551278] DEBUG: proplist: attention_DELAY = 100 (string)
[1.18446744073709551278] DEBUG: proplist: alarm_WAVEFORM = sine (string)
[1.18446744073709551278] DEBUG: proplist: attention_ALEVEL = 0 (string)
[1.18446744073709551278] DEBUG: proplist: ringtone_PERIOD = 100 (string)
[1.18446744073709551278] DEBUG: proplist: touch_strong_TYPE = rumble (string)
[1.18446744073709551278] DEBUG: proplist: ringtone_MAGNITUDE = 16383 (string)
[1.18446744073709551279] DEBUG: proplist: notice_PERIOD = 0 (string)
[1.18446744073709551279] DEBUG: proplist: drag_boundary_DURATION = 30 (string)
[1.18446744073709551279] DEBUG: proplist: long_ATTACK = 0 (string)
[1.18446744073709551279] DEBUG: proplist: message_MAGNITUDE = 27000 (string)
[1.18446744073709551279] DEBUG: proplist: release_strong_DURATION = 20 (string)
[1.18446744073709551279] DEBUG: proplist: ringtone_FADE = 300 (string)
[1.18446744073709551279] DEBUG: proplist: long_WAVEFORM = sine (string)
[1.18446744073709551279] DEBUG: proplist: touch_DURATION = 40 (string)
[1.18446744073709551279] DEBUG: proplist: touch_weak_MAGNITUDE = 20000 (string)
[1.18446744073709551279] DEBUG: proplist: ringtone_OFFSET = 0 (string)
[1.18446744073709551279] DEBUG: proplist: notice_OFFSET = 0 (string)
[1.18446744073709551279] DEBUG: proplist: attention_MAGNITUDE = 37000 (string)
[1.18446744073709551279] DEBUG: proplist: release_weak_DELAY = 0 (string)
[1.18446744073709551279] DEBUG: proplist: release_DURATION = 20 (string)
[1.18446744073709551279] DEBUG: proplist: ringtone_FLEVEL = 4096 (string)
[1.18446744073709551279] DEBUG: proplist: notice_FLEVEL = 0 (string)
[1.18446744073709551279] DEBUG: proplist: alarm_MAGNITUDE = 8000 (string)
[1.18446744073709551279] DEBUG: proplist: notice_WAVEFORM = sine (string)
[1.18446744073709551279] DEBUG: proplist: drag_fail_DELAY = 0 (string)
[1.18446744073709551279] DEBUG: proplist: drag_end_MAGNITUDE = 25000 (string)
[1.18446744073709551279] DEBUG: proplist: touch_DELAY = 0 (string)
[1.18446744073709551279] DEBUG: proplist: long_ALEVEL = 0 (string)
[1.18446744073709551279] DEBUG: proplist: release_weak_MAGNITUDE = 20000 (string)
[1.18446744073709551279] DEBUG: proplist: message_DELAY = 140 (string)
[1.18446744073709551279] DEBUG: proplist: notice_PHASE = 0 (string)
[1.18446744073709551279] DEBUG: proplist: drag_end_DELAY = 0 (string)
[1.18446744073709551279] DEBUG: core: sink interface 'ffmemless' registered
[1.18446744073709551279] DEBUG: core-dbus: get cached system bus
[1.18446744073709551279] DEBUG: core-dbus: new match 'type='signal',interface='org.nemomobile.lipstick.devicelock',path='/devicelock',member='stateChanged''
[1.18446744073709551279] DEBUG: core-dbus: add match callback 'type='signal',interface='org.nemomobile.lipstick.devicelock',path='/devicelock',member='stateChanged'' -> 4 : 0xfffff64bdb50
[1.18446744073709551279] DEBUG: core-dbus: get cached system bus
[1.18446744073709551279] DEBUG: core-dbus: do async call org.nemomobile.devicelock /devicelock org.nemomobile.lipstick.devicelock.state
[1.18446744073709551280] DEBUG: core: sink 'gst' priority set to 0
[1.18446744073709551280] DEBUG: tonegen: starting sink
[1.18446744073709551280] DEBUG: tonegen-dbusif: D-Bus setup OK
[1.18446744073709551289] DEBUG: tonegen-ausrv: Trying to connect to default Pulse Audio...
[1.18446744073709551289] DEBUG: canberra: sink initialize
[New Thread 0xffffee4900b0 (LWP 22176)]
[1.18446744073709551331] DEBUG: gst: initializing GStreamer
[1.18446744073709551412] DEBUG: ffmemless: No device_file_path provided, using automatic detection
[1.18446744073709551428] DEBUG: ffmemless: Successfully opened ff-memless event device
[1.18446744073709551428] DEBUG: ffmemless: creating effect list for touch;touch_weak;touch_strong;release;release_weak;release_strong;drag_start;drag_fail;drag_boundary_drag_end;short;strong;long;notice;message;attention;alarm;ringtone
[1.18446744073709551428] DEBUG: ffmemless: Added effect default, id 0
[1.18446744073709551428] DEBUG: ffmemless: got key drag_start, id -1
[1.18446744073709551429] DEBUG: ffmemless: Creating / updating effect drag_start
[1.18446744073709551429] DEBUG: ffmemless: For drag_start_DURATION got value 20
[1.18446744073709551429] DEBUG: ffmemless: For drag_start_REPEAT got value (null)
[1.18446744073709551429] DEBUG: ffmemless: For drag_start_DELAY got value 0
[1.18446744073709551429] DEBUG: ffmemless: rumble effect
[1.18446744073709551429] DEBUG: ffmemless: For drag_start_MAGNITUDE got value 25000
[1.18446744073709551429] DEBUG: ffmemless: Created effect drag_start with id 1
[1.18446744073709551429] DEBUG: ffmemless: Parameters:
type = 0x50
length = 20ms
delay = 0ms
strong rumble magn = 0x61a8
weak rumble magn = 0x61a8
per_waveform = 0x61a8
period = 25000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551429] DEBUG: ffmemless: got key long, id -1
[1.18446744073709551429] DEBUG: ffmemless: Creating / updating effect long
[1.18446744073709551429] DEBUG: ffmemless: For long_DURATION got value 850
[1.18446744073709551429] DEBUG: ffmemless: For long_REPEAT got value (null)
[1.18446744073709551429] DEBUG: ffmemless: For long_DELAY got value (null)
[1.18446744073709551429] DEBUG: ffmemless: periodic effect
[1.18446744073709551429] DEBUG: ffmemless: For long_PERIOD got value 150
[1.18446744073709551429] DEBUG: ffmemless: For long_MAGNITUDE got value 15383
[1.18446744073709551429] DEBUG: ffmemless: For long_OFFSET got value (null)
[1.18446744073709551429] DEBUG: ffmemless: For long_PHASE got value (null)
[1.18446744073709551429] DEBUG: ffmemless: For long_ATTACK got value 0
[1.18446744073709551429] DEBUG: ffmemless: For long_ALEVEL got value 0
[1.18446744073709551429] DEBUG: ffmemless: For long_FADE got value 180
[1.18446744073709551429] DEBUG: ffmemless: For long_FLEVEL got value 0
[1.18446744073709551429] DEBUG: ffmemless: Created effect long with id 2
[1.18446744073709551429] DEBUG: ffmemless: Parameters:
type = 0x51
length = 850ms
delay = 0ms
strong rumble magn = 0x5a
weak rumble magn = 0x96
per_waveform = 0x5a
period = 150ms
periodic magnitude = 0x3c17
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 180ms
fade_lev = 0x0

[1.18446744073709551429] DEBUG: ffmemless: got key release_weak, id -1
[1.18446744073709551429] DEBUG: ffmemless: Creating / updating effect release_weak
[1.18446744073709551429] DEBUG: ffmemless: For release_weak_DURATION got value 20
[1.18446744073709551429] DEBUG: ffmemless: For release_weak_REPEAT got value (null)
[1.18446744073709551429] DEBUG: ffmemless: For release_weak_DELAY got value 0
[1.18446744073709551429] DEBUG: ffmemless: rumble effect
[1.18446744073709551429] DEBUG: ffmemless: For release_weak_MAGNITUDE got value 20000
[1.18446744073709551429] DEBUG: ffmemless: Created effect release_weak with id 3
[1.18446744073709551429] DEBUG: ffmemless: Parameters:
type = 0x50
length = 20ms
delay = 0ms
strong rumble magn = 0x4e20
weak rumble magn = 0x4e20
per_waveform = 0x4e20
period = 20000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551429] DEBUG: ffmemless: got key default, id 0
[1.18446744073709551429] DEBUG: ffmemless: No default_TYPE defined, skipping
[1.18446744073709551429] DEBUG: ffmemless: got key release_strong, id -1
[1.18446744073709551429] DEBUG: ffmemless: Creating / updating effect release_strong
[1.18446744073709551429] DEBUG: ffmemless: For release_strong_DURATION got value 20
[1.18446744073709551429] DEBUG: ffmemless: For release_strong_REPEAT got value (null)
[1.18446744073709551429] DEBUG: ffmemless: For release_strong_DELAY got value 0
[1.18446744073709551429] DEBUG: ffmemless: rumble effect
[1.18446744073709551429] DEBUG: ffmemless: For release_strong_MAGNITUDE got value 30000
[1.18446744073709551430] DEBUG: ffmemless: Created effect release_strong with id 4
[1.18446744073709551430] DEBUG: ffmemless: Parameters:
type = 0x50
length = 20ms
delay = 0ms
strong rumble magn = 0x7530
weak rumble magn = 0x7530
per_waveform = 0x7530
period = 30000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551430] DEBUG: ffmemless: got key drag_boundary_drag_end, id -1
[1.18446744073709551430] DEBUG: ffmemless: No drag_boundary_drag_end_TYPE defined, skipping
[1.18446744073709551430] DEBUG: ffmemless: got key alarm, id -1
[1.18446744073709551430] DEBUG: ffmemless: Creating / updating effect alarm
[1.18446744073709551430] DEBUG: ffmemless: For alarm_DURATION got value 4000
[1.18446744073709551430] DEBUG: ffmemless: For alarm_REPEAT got value (null)
[1.18446744073709551430] DEBUG: ffmemless: For alarm_DELAY got value 500
[1.18446744073709551430] DEBUG: ffmemless: periodic effect
[1.18446744073709551430] DEBUG: ffmemless: For alarm_PERIOD got value 100
[1.18446744073709551430] DEBUG: ffmemless: For alarm_MAGNITUDE got value 8000
[1.18446744073709551430] DEBUG: ffmemless: For alarm_OFFSET got value 0
[1.18446744073709551430] DEBUG: ffmemless: For alarm_PHASE got value 0
[1.18446744073709551430] DEBUG: ffmemless: For alarm_ATTACK got value 1000
[1.18446744073709551430] DEBUG: ffmemless: For alarm_ALEVEL got value 0
[1.18446744073709551430] DEBUG: ffmemless: For alarm_FADE got value 400
[1.18446744073709551430] DEBUG: ffmemless: For alarm_FLEVEL got value 0
[1.18446744073709551430] DEBUG: ffmemless: Created effect alarm with id 5
[1.18446744073709551430] DEBUG: ffmemless: Parameters:
type = 0x51
length = 4000ms
delay = 500ms
strong rumble magn = 0x5a
weak rumble magn = 0x64
per_waveform = 0x5a
period = 100ms
periodic magnitude = 0x1f40
offset = 0x0
phase = 0
att = 1000ms
att_lev = 0x0
fade = 400ms
fade_lev = 0x0
[1.18446744073709551430] DEBUG: ffmemless: got key notice, id -1
[1.18446744073709551430] DEBUG: ffmemless: Creating / updating effect notice
[1.18446744073709551430] DEBUG: ffmemless: For notice_DURATION got value 100
[1.18446744073709551430] DEBUG: ffmemless: For notice_REPEAT got value 2
[1.18446744073709551430] DEBUG: ffmemless: For notice_DELAY got value 500
[1.18446744073709551430] DEBUG: ffmemless: periodic effect
[1.18446744073709551430] DEBUG: ffmemless: For notice_PERIOD got value 0
[1.18446744073709551430] DEBUG: ffmemless: For notice_MAGNITUDE got value 47000
[1.18446744073709551430] DEBUG: ffmemless: notice_MAGNITUDE too high, rounding to 32767
[1.18446744073709551430] DEBUG: ffmemless: For notice_OFFSET got value 0
[1.18446744073709551430] DEBUG: ffmemless: For notice_PHASE got value 0
[1.18446744073709551430] DEBUG: ffmemless: For notice_ATTACK got value 0
[1.18446744073709551430] DEBUG: ffmemless: For notice_ALEVEL got value 0
[1.18446744073709551430] DEBUG: ffmemless: For notice_FADE got value 5
[1.18446744073709551430] DEBUG: ffmemless: For notice_FLEVEL got value 0
[1.18446744073709551430] DEBUG: ffmemless: Created effect notice with id 6
[1.18446744073709551430] DEBUG: ffmemless: Parameters:
type = 0x51
length = 100ms
delay = 500ms
strong rumble magn = 0x5a
weak rumble magn = 0x0
per_waveform = 0x5a
period = 0ms
periodic magnitude = 0x7fff
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 5ms
fade_lev = 0x0

[1.18446744073709551430] DEBUG: ffmemless: got key drag_fail, id -1
[1.18446744073709551430] DEBUG: ffmemless: Creating / updating effect drag_fail
[1.18446744073709551430] DEBUG: ffmemless: For drag_fail_DURATION got value 25
[1.18446744073709551430] DEBUG: ffmemless: For drag_fail_REPEAT got value (null)
[1.18446744073709551430] DEBUG: ffmemless: For drag_fail_DELAY got value 0
[1.18446744073709551430] DEBUG: ffmemless: rumble effect
[1.18446744073709551430] DEBUG: ffmemless: For drag_fail_MAGNITUDE got value 25000
[1.18446744073709551430] DEBUG: ffmemless: Created effect drag_fail with id 7
[1.18446744073709551430] DEBUG: ffmemless: Parameters:
type = 0x50
length = 25ms
delay = 0ms
strong rumble magn = 0x61a8
weak rumble magn = 0x61a8
per_waveform = 0x61a8
period = 25000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551430] DEBUG: ffmemless: got key touch_weak, id -1
[1.18446744073709551430] DEBUG: ffmemless: Creating / updating effect touch_weak
[1.18446744073709551430] DEBUG: ffmemless: For touch_weak_DURATION got value 40
[1.18446744073709551430] DEBUG: ffmemless: For touch_weak_REPEAT got value (null)
[1.18446744073709551430] DEBUG: ffmemless: For touch_weak_DELAY got value 0
[1.18446744073709551430] DEBUG: ffmemless: rumble effect
[1.18446744073709551431] DEBUG: ffmemless: For touch_weak_MAGNITUDE got value 20000
[1.18446744073709551431] DEBUG: ffmemless: Created effect touch_weak with id 8
[1.18446744073709551431] DEBUG: ffmemless: Parameters:
type = 0x50
length = 40ms
delay = 0ms
strong rumble magn = 0x4e20
weak rumble magn = 0x4e20
per_waveform = 0x4e20
period = 20000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551431] DEBUG: ffmemless: got key short, id -1
[1.18446744073709551431] DEBUG: ffmemless: Creating / updating effect short
[1.18446744073709551431] DEBUG: ffmemless: For short_DURATION got value 80
[1.18446744073709551431] DEBUG: ffmemless: For short_REPEAT got value (null)
[1.18446744073709551431] DEBUG: ffmemless: For short_DELAY got value 0
[1.18446744073709551431] DEBUG: ffmemless: rumble effect
[1.18446744073709551431] DEBUG: ffmemless: For short_MAGNITUDE got value 24000
[1.18446744073709551431] DEBUG: ffmemless: Created effect short with id 9
[1.18446744073709551431] DEBUG: ffmemless: Parameters:
type = 0x50
length = 80ms
delay = 0ms
strong rumble magn = 0x5dc0
weak rumble magn = 0x5dc0
per_waveform = 0x5dc0
period = 24000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551431] DEBUG: ffmemless: got key ringtone, id -1
[1.18446744073709551431] DEBUG: ffmemless: Creating / updating effect ringtone
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_DURATION got value 2400
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_REPEAT got value (null)
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_DELAY got value 400
[1.18446744073709551431] DEBUG: ffmemless: periodic effect
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_PERIOD got value 100
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_MAGNITUDE got value 16383
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_OFFSET got value 0
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_PHASE got value 0
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_ATTACK got value 500
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_ALEVEL got value 2560
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_FADE got value 300
[1.18446744073709551431] DEBUG: ffmemless: For ringtone_FLEVEL got value 4096
[1.18446744073709551431] DEBUG: ffmemless: Created effect ringtone with id 10
[1.18446744073709551431] DEBUG: ffmemless: Parameters:
type = 0x51
length = 2400ms
delay = 400ms
strong rumble magn = 0x5a
weak rumble magn = 0x64
per_waveform = 0x5a
period = 100ms
periodic magnitude = 0x3fff
offset = 0x0
phase = 0
att = 500ms
att_lev = 0xa00
fade = 300ms
fade_lev = 0x
[1.18446744073709551431] DEBUG: ffmemless: got key message, id -1
[1.18446744073709551431] DEBUG: ffmemless: Creating / updating effect message
[1.18446744073709551431] DEBUG: ffmemless: For message_DURATION got value 240
[1.18446744073709551431] DEBUG: ffmemless: For message_REPEAT got value 2
[1.18446744073709551431] DEBUG: ffmemless: For message_DELAY got value 140
[1.18446744073709551431] DEBUG: ffmemless: periodic effect
[1.18446744073709551431] DEBUG: ffmemless: For message_PERIOD got value 50
[1.18446744073709551431] DEBUG: ffmemless: For message_MAGNITUDE got value 27000
[1.18446744073709551431] DEBUG: ffmemless: For message_OFFSET got value 0
[1.18446744073709551431] DEBUG: ffmemless: For message_PHASE got value 0
[1.18446744073709551431] DEBUG: ffmemless: For message_ATTACK got value 0
[1.18446744073709551431] DEBUG: ffmemless: For message_ALEVEL got value 0
[1.18446744073709551431] DEBUG: ffmemless: For message_FADE got value 80
[1.18446744073709551431] DEBUG: ffmemless: For message_FLEVEL got value 0
[1.18446744073709551431] DEBUG: ffmemless: Created effect message with id 11
[1.18446744073709551431] DEBUG: ffmemless: Parameters:
type = 0x51
length = 240ms
delay = 140ms
strong rumble magn = 0x5a
weak rumble magn = 0x32
per_waveform = 0x5a
period = 50ms
periodic magnitude = 0x6978
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 80ms
fade_lev = 0x0

[1.18446744073709551431] DEBUG: ffmemless: got key touch, id -1
[1.18446744073709551431] DEBUG: ffmemless: Creating / updating effect touch
[1.18446744073709551431] DEBUG: ffmemless: For touch_DURATION got value 40
[1.18446744073709551431] DEBUG: ffmemless: For touch_REPEAT got value (null)
[1.18446744073709551431] DEBUG: ffmemless: For touch_DELAY got value 0
[1.18446744073709551431] DEBUG: ffmemless: rumble effect
[1.18446744073709551431] DEBUG: ffmemless: For touch_MAGNITUDE got value 24000
[1.18446744073709551431] DEBUG: ffmemless: Created effect touch with id 12
[1.18446744073709551431] DEBUG: ffmemless: Parameters:
type = 0x50
length = 40ms
delay = 0ms
strong rumble magn = 0x5dc0
weak rumble magn = 0x5dc0
per_waveform = 0x5dc0
period = 24000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551431] DEBUG: ffmemless: got key attention, id -1
[1.18446744073709551431] DEBUG: ffmemless: Creating / updating effect attention
[1.18446744073709551431] DEBUG: ffmemless: For attention_DURATION got value 100
[1.18446744073709551431] DEBUG: ffmemless: For attention_REPEAT got value 3
[1.18446744073709551431] DEBUG: ffmemless: For attention_DELAY got value 100
[1.18446744073709551431] DEBUG: ffmemless: periodic effect
[1.18446744073709551432] DEBUG: ffmemless: For attention_PERIOD got value 0
[1.18446744073709551432] DEBUG: ffmemless: For attention_MAGNITUDE got value 37000
[1.18446744073709551432] DEBUG: ffmemless: attention_MAGNITUDE too high, rounding to 32767
[1.18446744073709551432] DEBUG: ffmemless: For attention_OFFSET got value 0
[1.18446744073709551432] DEBUG: ffmemless: For attention_PHASE got value 0
[1.18446744073709551432] DEBUG: ffmemless: For attention_ATTACK got value 0
[1.18446744073709551432] DEBUG: ffmemless: For attention_ALEVEL got value 0
[1.18446744073709551432] DEBUG: ffmemless: For attention_FADE got value 5
[1.18446744073709551432] DEBUG: ffmemless: For attention_FLEVEL got value 0
[1.18446744073709551432] DEBUG: ffmemless: Created effect attention with id 13
[1.18446744073709551432] DEBUG: ffmemless: Parameters:
type = 0x51
length = 100ms
delay = 100ms
strong rumble magn = 0x5a
weak rumble magn = 0x0
per_waveform = 0x5a
period = 0ms
periodic magnitude = 0x7fff
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 5ms
fade_lev = 0x0

[1.18446744073709551432] DEBUG: ffmemless: got key touch_strong, id -1
[1.18446744073709551432] DEBUG: ffmemless: Creating / updating effect touch_strong
[1.18446744073709551432] DEBUG: ffmemless: For touch_strong_DURATION got value 40
[1.18446744073709551432] DEBUG: ffmemless: For touch_strong_REPEAT got value (null)
[1.18446744073709551432] DEBUG: ffmemless: For touch_strong_DELAY got value 0
[1.18446744073709551432] DEBUG: ffmemless: rumble effect
[1.18446744073709551432] DEBUG: ffmemless: For touch_strong_MAGNITUDE got value 30000
[1.18446744073709551432] DEBUG: ffmemless: Created effect touch_strong with id 14
[1.18446744073709551432] DEBUG: ffmemless: Parameters:
type = 0x50
length = 40ms
delay = 0ms
strong rumble magn = 0x7530
weak rumble magn = 0x7530
per_waveform = 0x7530
period = 30000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551432] DEBUG: ffmemless: got key release, id -1
[1.18446744073709551432] DEBUG: ffmemless: Creating / updating effect release
[1.18446744073709551432] DEBUG: ffmemless: For release_DURATION got value 20
[1.18446744073709551432] DEBUG: ffmemless: For release_REPEAT got value (null)
[1.18446744073709551432] DEBUG: ffmemless: For release_DELAY got value 0
[1.18446744073709551432] DEBUG: ffmemless: rumble effect
[1.18446744073709551432] DEBUG: ffmemless: For release_MAGNITUDE got value 24000
[1.18446744073709551432] DEBUG: ffmemless: Created effect release with id 15
[1.18446744073709551432] DEBUG: ffmemless: Parameters:
type = 0x50
length = 20ms
delay = 0ms
strong rumble magn = 0x5dc0
weak rumble magn = 0x5dc0
per_waveform = 0x5dc0
period = 24000ms
periodic magnitude = 0x0
offset = 0x0
phase = 0
att = 0ms
att_lev = 0x0
fade = 0ms
fade_lev = 0x0

[1.18446744073709551432] DEBUG: ffmemless: got key strong, id -1
[1.18446744073709551432] DEBUG: ffmemless: Creating / updating effect strong
[1.18446744073709551432] DEBUG: ffmemless: For strong_DURATION got value 80
[1.18446744073709551432] DEBUG: ffmemless: For strong_REPEAT got value (null)
[1.18446744073709551432] DEBUG: ffmemless: For strong_DELAY got value 0
[1.18446744073709551432] DEBUG: ffmemless: rumble effect
[1.18446744073709551432] DEBUG: ffmemless: For strong_MAGNITUDE got value 65535
Vibra upload effect: No space left on device
[1.18446744073709551432] DEBUG: ffmemless: strong effect loading failed
[1.18446744073709551432] ERROR: ffmemless: Could not load ngfd effects
malloc(): unaligned fastbin chunk detected

Thread 1 "ngfd" received signal SIGABRT, Aborted.
0x0000fffff7ac26c8 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x0000fffff7ac26c8 in raise () at /usr/lib/libc.so.6
#1  0x0000fffff7aaf1cc in abort () at /usr/lib/libc.so.6
#2  0x0000fffff7afb870 in __libc_message () at /usr/lib/libc.so.6
#3  0x0000fffff7b033ac in  () at /usr/lib/libc.so.6
#4  0x0000fffff7b06660 in _int_malloc () at /usr/lib/libc.so.6
#5  0x0000fffff7b0718c in _int_realloc () at /usr/lib/libc.so.6
#6  0x0000fffff7b08470 in realloc () at /usr/lib/libc.so.6
#7  0x0000fffff7da1d58 in g_realloc () at /usr/lib/libglib-2.0.so.0
#8  0x0000fffff7dc41c0 in g_string_insert_len () at /usr/lib/libglib-2.0.so.0
#9  0x0000fffff7da3e2c in g_log_writer_format_fields () at /usr/lib/libglib-2.0.so.0
#10 0x0000fffff7da4ff0 in g_log_writer_standard_streams () at /usr/lib/libglib-2.0.so.0
#11 0x0000fffff7da516c in g_log_writer_default () at /usr/lib/libglib-2.0.so.0
#12 0x0000fffff7da2fc0 in g_log_structured_array () at /usr/lib/libglib-2.0.so.0
#13 0x0000fffff7da34b0 in g_log_default_handler () at /usr/lib/libglib-2.0.so.0
#14 0x0000fffff7da3760 in g_logv () at /usr/lib/libglib-2.0.so.0
#15 0x0000fffff7da3a4c in g_log () at /usr/lib/libglib-2.0.so.0
#16 0x0000fffff7db133c in g_atomic_ref_count_dec () at /usr/lib/libglib-2.0.so.0
#17 0x0000fffff7d844c4 in g_hash_table_unref () at /usr/lib/libglib-2.0.so.0
#18 0x0000fffff64d29ec in ffm_sink_initialize (iface=<optimized out>) at plugin.c:534
#19 ffm_sink_initialize (iface=<optimized out>) at plugin.c:502
#20 0x0000aaaaaaaa79c4 in n_core_initialize (core=0xaaaaaaad4e60) at core.c:479
#21 0x0000aaaaaaaa5fe4 in main (argc=<optimized out>, argv=0xfffffffffb38) at main.c:193
```