### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/ngfd.spec
+++ b/rpm/ngfd.spec
@@ -24,9 +24,9 @@ BuildRequires:  pkgconfig(mce)
 BuildRequires:  pkgconfig(profile)
 BuildRequires:  pkgconfig(libcanberra)
 BuildRequires:  pkgconfig(ohm-ext-route)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  libtool
 BuildRequires:  doxygen
-BuildRequires:  systemd-devel
 Obsoletes:      tone-generator <= 1.5.4
 Provides:       tone-generator > 1.5.4
 


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.