### PR TITLE
[ngfd] Fix unit tests not having proper plugin path. Fixes JB#52769

### DIFF
--- a/src/ngf/core.c
+++ b/src/ngf/core.c
@@ -309,6 +309,9 @@ n_core_new (int *argc, char **argv)
     core = g_new0 (NCore, 1);
 
     /* query the default paths */
+#ifndef DEFAULT_PLUGIN_PATH
+#error "DEFAULT_PLUGIN_PATH needs to be defined"
+#endif
 
     core->conf_path         = n_core_get_path ("NGF_CONF_PATH", DEFAULT_CONF_PATH);
     core->user_conf_path    = n_core_get_path ("NGF_USER_CONF_PATH", DEFAULT_USER_CONF_PATH);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,7 +24,7 @@ tests_PROGRAMS = \
 tests_DATA = \
        tests.xml
 
-AM_CFLAGS = -I$(top_srcdir)/src/include
+AM_CFLAGS = -I$(top_srcdir)/src/include -DDEFAULT_PLUGIN_PATH=@NGFD_PLUGIN_DIR@
 
 test_value_SOURCES = test-value.c $(top_srcdir)/src/ngf/value.c $(top_srcdir)/src/ngf/log.c
 test_value_CFLAGS = @CHECK_CFLAGS@ @NGFD_CFLAGS@ $(AM_CFLAGS)


### PR DESCRIPTION
Commit 61abea70f made the plugin path depend on a macro but passed
the value only on the ngfd side. Unit test compiled the core.c separately
and got "DEFAULT_PLUGIN_PATH" as plugin path.

@mlehtima @Tomin1 @spiiroin 