### PR TITLE
Fix raciness on MCE plugin. JB#61050

### DIFF
--- a/src/include/ngf/haptic.h
+++ b/src/include/ngf/haptic.h
@@ -92,7 +92,7 @@
  * This function should be used by all haptic feedback plugins in their
  * _sink_can_handle() function to determine whether the event should be
  * played or not. It will take care of returning FALSE in case vibration
- * feedback is diabled or if phone calls are active. If it returns TRUE,
+ * feedback is disabled or if phone calls are active. If it returns TRUE,
  * the plugin can do additional checks (e.g. whether or not it has an
  * effect for the request). The interface is kept in line with the
  * definition in NSinkInterfaceDecl, so in case the plugin does not have

--- a/src/ngf/core-player.c
+++ b/src/ngf/core-player.c
@@ -256,8 +256,8 @@ n_core_stop_sinks (GList *sinks, NRequest *request)
 
     for (iter = g_list_first (sinks); iter; iter = g_list_next (iter)) {
         sink = (NSinkInterface*) iter->data;
-	 if (sink && sink->funcs.stop)
-	     sink->funcs.stop (sink, request);
+        if (sink && sink->funcs.stop)
+            sink->funcs.stop (sink, request);
     }
 }
 

--- a/src/plugins/ffmemless/ffmemless.c
+++ b/src/plugins/ffmemless/ffmemless.c
@@ -69,7 +69,7 @@ int ffmemless_erase_effect(int effect_id, int device_file)
 
 int ffmemless_evdev_file_open(const char *file_name, unsigned long features[4])
 {
-	int result, fp;
+	int fp;
 
 	fp = open(file_name, O_RDWR | O_CLOEXEC);
 


### PR DESCRIPTION
Scenario:
- have event in play state, optionally wait some time before continuing
- stop event
- restart event quickly after the previous
- mce signal for stop arrives, previous restart is still pending on mce
- code calls n_sink_interface_complete, which seems to trigger yet another stop.
    
Thus now tracking for active event when mce reports them playing and ignoring the deactivation signal that comes too soon. Stop also tracks what's expecting to be active.

Also another commit for a couple minor cleanups.