### PR TITLE
Fix unit tests

### DIFF
--- a/src/include/ngf/context.h
+++ b/src/include/ngf/context.h
@@ -39,7 +39,7 @@ typedef void (*NContextValueChangeFunc) (NContext *context,
  *
  * @param context NContext structure.
  * @param key Key.
- * @param value Values as NValue type.
+ * @param value Values as NValue type. Context takes over the ownership.
  */
 void          n_context_set_value                (NContext *context, const char *key,
                                                   NValue *value);

--- a/src/include/ngf/proplist.h
+++ b/src/include/ngf/proplist.h
@@ -106,7 +106,7 @@ gboolean    n_proplist_match_exact (const NProplist *a, const NProplist *b);
 /** Insert or update key/value pair in proplist
  * @param proplist Proplist
  * @param key Key
- * @param value Value
+ * @param value Value. Proplist takes ownership of the value.
  */
 void        n_proplist_set         (NProplist *proplist, const char *key, const NValue *value);
 

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -8,7 +8,7 @@ START_TEST (test_set_get_value)
 {
     NContext *context = NULL;
     context = n_context_new ();
-    fail_unless (context != NULL);
+    ck_assert (context != NULL);
 
     const char *key = "key";
     NValue *value = NULL;
@@ -17,20 +17,20 @@ START_TEST (test_set_get_value)
     n_value_set_int (value, -100);
 
     /* gets value with some NULL arguments */
-    fail_unless (n_context_get_value (context, NULL) == NULL);
-    fail_unless (n_context_get_value (NULL, key) == NULL);
+    ck_assert (n_context_get_value (context, NULL) == NULL);
+    ck_assert (n_context_get_value (NULL, key) == NULL);
 
     /* sets value sith some NULL arguments */
     n_context_set_value (NULL, key, value);
-    fail_unless (n_context_get_value (context, key) == NULL);
+    ck_assert (n_context_get_value (context, key) == NULL);
     n_context_set_value (context, NULL, value);
-    fail_unless (n_context_get_value (context, key) == NULL);
+    ck_assert (n_context_get_value (context, key) == NULL);
 
     /* calls set value with valid arguments */
     n_context_set_value (context, key, value);
     const NValue *ret_val = n_context_get_value (context, key);
 
-    fail_unless (n_value_equals (ret_val, value) == TRUE);
+    ck_assert (n_value_equals (ret_val, value) == TRUE);
 
     value = NULL;
     n_context_free (context);
@@ -51,46 +51,46 @@ START_TEST (test_subscribe_unsubscribe_value_change)
 {
     NContext *context = NULL;
     context = n_context_new ();
-    fail_unless (context != NULL);
+    ck_assert (context != NULL);
     const char *key = "key";
     gboolean result = TRUE;
     int item = 0;
 
     /* subscribe */
     result = n_context_subscribe_value_change (NULL, key, n_context_callback, NULL);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 0);
+    ck_assert (item == 0);
     result = n_context_subscribe_value_change (context, key, NULL, NULL);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 0);
+    ck_assert (item == 0);
     /* proper subscribtion */
     result = n_context_subscribe_value_change (context, key, n_context_callback, NULL);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 1);
+    ck_assert (item == 1);
 
     /* unsubscribe */
     n_context_unsubscribe_value_change (NULL, key, n_context_callback);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 1);
+    ck_assert (item == 1);
     n_context_unsubscribe_value_change (context, NULL, n_context_callback);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 1);
+    ck_assert (item == 1);
     n_context_unsubscribe_value_change (context, key, NULL);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 1);
+    ck_assert (item == 1);
     /* proper unsubscribtion */
     n_context_unsubscribe_value_change (context, key, n_context_callback);
     item = g_hash_table_size (context->keys);
-    fail_unless (item == 0);
+    ck_assert (item == 0);
 
     /* subscribe callback to key=NULL */
     result = n_context_subscribe_value_change (context, NULL, n_context_callback, NULL);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     item = g_list_length (context->all_keys);
-    fail_unless (item == 1);
+    ck_assert (item == 1);
     /*
      * TODO: unsubscribe callback when key=NULL
      * */

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -32,7 +32,6 @@ START_TEST (test_set_get_value)
 
     fail_unless (n_value_equals (ret_val, value) == TRUE);
 
-    n_value_free (value);
     value = NULL;
     n_context_free (context);
     context = NULL;

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -83,7 +83,6 @@ START_TEST (test_add_get_events)
     NEvent *receivedEvent = (NEvent*)events->data;
     fail_unless (g_strcmp0 (receivedEvent->name, "sms") == 0);
 
-    g_list_free (events);
     events = NULL;
     n_core_free (core);
     core = NULL;

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -9,12 +9,12 @@ START_TEST (test_create)
 {
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
-    fail_unless (core->conf_path != NULL);
-    fail_unless (core->plugin_path != NULL);
-    fail_unless (core->context != NULL);
-    fail_unless (core->eventlist != NULL);
-    fail_unless (core->key_types != NULL);
+    ck_assert (core != NULL);
+    ck_assert (core->conf_path != NULL);
+    ck_assert (core->plugin_path != NULL);
+    ck_assert (core->context != NULL);
+    ck_assert (core->eventlist != NULL);
+    ck_assert (core->key_types != NULL);
 
     n_core_free (core);
     core = NULL;
@@ -24,16 +24,16 @@ END_TEST
 START_TEST (test_get_context)
 {
     NCore *core = NULL;
-    fail_unless (n_core_get_context (core) == NULL);
+    ck_assert (n_core_get_context (core) == NULL);
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
-    fail_unless (n_core_get_context (core) != NULL);
+    ck_assert (core != NULL);
+    ck_assert (n_core_get_context (core) != NULL);
     NContext *context = n_context_new ();
     n_context_free (core->context);
     core->context = context;
     NContext *received_context = n_core_get_context (core);
-    fail_unless (received_context != NULL);
-    fail_unless (received_context == context);
+    ck_assert (received_context != NULL);
+    ck_assert (received_context == context);
 
     n_core_free (core);
     core = NULL;
@@ -43,17 +43,17 @@ END_TEST
 START_TEST (test_get_requests)
 {
     NCore *core = NULL;
-    fail_unless (n_core_get_requests (core) == NULL);
+    ck_assert (n_core_get_requests (core) == NULL);
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
-    fail_unless (n_core_get_requests (core) == NULL);
+    ck_assert (core != NULL);
+    ck_assert (n_core_get_requests (core) == NULL);
     NRequest *request = n_request_new ();
     GList *list = NULL;
     list = g_list_append (list, request);
     core->requests = list;
     GList *received_list = n_core_get_requests (core);
-    fail_unless (received_list != NULL);
-    fail_unless (received_list == list);
+    ck_assert (received_list != NULL);
+    ck_assert (received_list == list);
 
     n_core_free (core);
     core = NULL;
@@ -63,10 +63,10 @@ END_TEST
 START_TEST (test_add_get_events)
 {
     NCore *core = NULL;
-    fail_unless (n_core_get_events (core) == NULL);
+    ck_assert (n_core_get_events (core) == NULL);
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
-    fail_unless (n_core_get_events (core) == NULL);
+    ck_assert (core != NULL);
+    ck_assert (n_core_get_events (core) == NULL);
 
     GKeyFile *keyfile = NULL;
     keyfile = g_key_file_new ();
@@ -76,12 +76,12 @@ START_TEST (test_add_get_events)
 
     GList *events = NULL;
     events = n_core_get_events (core);
-    fail_unless (events != NULL);
+    ck_assert (events != NULL);
 
     uint length = g_list_length (events);
-    fail_unless (length == 1);
+    ck_assert (length == 1);
     NEvent *receivedEvent = (NEvent*)events->data;
-    fail_unless (g_strcmp0 (receivedEvent->name, "sms") == 0);
+    ck_assert (g_strcmp0 (receivedEvent->name, "sms") == 0);
 
     events = NULL;
     n_core_free (core);
@@ -100,7 +100,7 @@ START_TEST (test_connect)
 {
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     gboolean result = TRUE;
     int priority = 10;
     NCoreHook hook = N_CORE_HOOK_INIT_DONE;
@@ -108,46 +108,46 @@ START_TEST (test_connect)
     GList *list = NULL;
     
     list = core->hooks[hook].slots;
-    fail_unless (g_list_length (list) == 0);
+    ck_assert (g_list_length (list) == 0);
     list = NULL;
 
     /* connect tests */
     
     /* core is NULL */
     result = n_core_connect (NULL, hook, priority, callback, userdata);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     
     /* callback is NULL */
     result = n_core_connect (core, hook, priority, NULL, userdata);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     
     /* hook >= N_CORE_HOOK_LAST */
     hook = N_CORE_HOOK_LAST;
     result = n_core_connect (core, hook, priority, callback, userdata);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     
     /* valid case */
     hook = N_CORE_HOOK_INIT_DONE;
     result = n_core_connect (core, hook, priority, callback, userdata);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     list = core->hooks[hook].slots;
-    fail_unless (list != NULL);
-    fail_unless (g_list_length (list) == 1);
+    ck_assert (list != NULL);
+    ck_assert (g_list_length (list) == 1);
 
     /* disconnect tests */
 
     /* core is NULL */
     n_core_disconnect (NULL, hook, callback, userdata);
     list = core->hooks[hook].slots;
-    fail_unless (list != NULL);
-    fail_unless (g_list_length (list) == 1);
+    ck_assert (list != NULL);
+    ck_assert (g_list_length (list) == 1);
     list = NULL;
 
     /* callback is NULL */
     n_core_disconnect (core, hook, NULL, userdata);
     list = core->hooks[hook].slots;
-    fail_unless (list != NULL);
-    fail_unless (g_list_length (list) == 1);
+    ck_assert (list != NULL);
+    ck_assert (g_list_length (list) == 1);
     list = NULL;
 
     /* hook >= N_CORE_HOOK_LAST */
@@ -158,8 +158,8 @@ START_TEST (test_connect)
     hook = N_CORE_HOOK_INIT_DONE;
     n_core_disconnect (core, hook, callback, userdata);
     list = core->hooks[hook].slots;
-    fail_unless (list == NULL);
-    fail_unless (g_list_length (list) == 0);
+    ck_assert (list == NULL);
+    ck_assert (g_list_length (list) == 0);
 
     n_core_free (core);
     core = NULL;

--- a/tests/test-event.c
+++ b/tests/test-event.c
@@ -9,7 +9,7 @@ START_TEST (test_create)
 {
     NEvent *event = NULL;
     event = n_event_new ();
-    fail_unless (event != NULL);
+    ck_assert (event != NULL);
 
     n_event_free (event);
     event = NULL;

--- a/tests/test-inputinterface.c
+++ b/tests/test-inputinterface.c
@@ -10,17 +10,17 @@ START_TEST (test_get_core)
 {
     NInputInterface *iface = NULL;
     iface = g_new0 (NInputInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     /* NULL checking */
-    fail_unless (n_input_interface_get_core (iface) == NULL);
+    ck_assert (n_input_interface_get_core (iface) == NULL);
     NCore *core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     core->conf_path = g_strdup ("conf_path");
     iface->core = core;
     NCore *receivedCore = NULL;
     receivedCore = n_input_interface_get_core (iface);
-    fail_unless (receivedCore != NULL);
-    fail_unless (g_strcmp0 (receivedCore->conf_path, core->conf_path) == 0);
+    ck_assert (receivedCore != NULL);
+    ck_assert (g_strcmp0 (receivedCore->conf_path, core->conf_path) == 0);
 
     n_core_free (core);
     core = NULL;
@@ -96,7 +96,7 @@ START_TEST (test_play_pause_request)
 
     NInputInterface *iface = NULL;
     iface = g_new0 (NInputInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     NCore *core = n_core_new (NULL, NULL);
     const char *event_name = "testing_event";
 
@@ -107,34 +107,34 @@ START_TEST (test_play_pause_request)
     g_key_file_free (keyfile);
 
     NPlugin *plugin = g_new0 (NPlugin, 1);
-    fail_unless (plugin != NULL);
+    ck_assert (plugin != NULL);
     plugin->core = core;
     n_plugin_register_sink (plugin, &decl);
     iface->core = core;
     NRequest *request = NULL;
     NProplist *proplist = n_proplist_new ();
     request = n_request_new_with_event_and_properties (event_name, proplist);
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     Data *data = NULL;
     /* play */
-    fail_unless (n_input_interface_play_request (NULL, request) == FALSE);
-    fail_unless (n_input_interface_play_request (iface, NULL) == FALSE);
-    fail_unless (n_input_interface_play_request (iface, request) == TRUE);
+    ck_assert (n_input_interface_play_request (NULL, request) == FALSE);
+    ck_assert (n_input_interface_play_request (iface, NULL) == FALSE);
+    ck_assert (n_input_interface_play_request (iface, request) == TRUE);
     data = (Data*) n_request_get_data (request, DATA_KEY);
-    fail_unless (data->state == PREPARED);
+    ck_assert (data->state == PREPARED);
     /* pause*/
-    fail_unless (n_input_interface_pause_request (NULL, request) == FALSE);
-    fail_unless (n_input_interface_pause_request (iface, NULL) == FALSE);
-    fail_unless (n_input_interface_pause_request (iface, request) == TRUE);
+    ck_assert (n_input_interface_pause_request (NULL, request) == FALSE);
+    ck_assert (n_input_interface_pause_request (iface, NULL) == FALSE);
+    ck_assert (n_input_interface_pause_request (iface, request) == TRUE);
     data = (Data*) n_request_get_data (request, DATA_KEY);
-    fail_unless (data->state == PAUSED);
-    fail_unless (n_input_interface_pause_request (iface, request) == TRUE);
+    ck_assert (data->state == PAUSED);
+    ck_assert (n_input_interface_pause_request (iface, request) == TRUE);
     data = (Data*) n_request_get_data (request, DATA_KEY);
-    fail_unless (data->state == PAUSED);
+    ck_assert (data->state == PAUSED);
     /* resume */
-    fail_unless (n_input_interface_play_request (iface, request) == TRUE);
+    ck_assert (n_input_interface_play_request (iface, request) == TRUE);
     data = (Data*) n_request_get_data (request, DATA_KEY);
-    fail_unless (data->state == PLAYING);
+    ck_assert (data->state == PLAYING);
     
     g_free (iface);
     iface = NULL;

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -10,17 +10,17 @@ START_TEST (test_get_core)
 {
     NPlugin *plugin = NULL;
     /* NULL checking */
-    fail_unless (n_plugin_get_core (plugin) == NULL);
+    ck_assert (n_plugin_get_core (plugin) == NULL);
     plugin = g_new0 (NPlugin, 1);
-    fail_unless (plugin != NULL);
+    ck_assert (plugin != NULL);
 
     NCore *core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     core->conf_path = g_strdup ("conf_path");
     plugin->core = core;
     NCore *receivedCore = n_plugin_get_core (plugin);
-    fail_unless (receivedCore != NULL);
-    fail_unless (g_strcmp0 (receivedCore->conf_path, core->conf_path) == 0);
+    ck_assert (receivedCore != NULL);
+    ck_assert (g_strcmp0 (receivedCore->conf_path, core->conf_path) == 0);
 
     g_free (plugin);
     plugin = NULL;
@@ -31,9 +31,9 @@ START_TEST (test_get_params)
 {
     NPlugin *plugin = NULL;
     /* NULL checking */
-    fail_unless (n_plugin_get_params (plugin) == NULL);
+    ck_assert (n_plugin_get_params (plugin) == NULL);
     plugin = g_new0 (NPlugin, 1);
-    fail_unless (plugin != NULL);
+    ck_assert (plugin != NULL);
 
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
@@ -42,8 +42,8 @@ START_TEST (test_get_params)
     const char *key1 = "key1";
     n_proplist_set_int (proplist, key1, -100);
     receivedParams = n_plugin_get_params (plugin);
-    fail_unless (receivedParams != NULL);
-    fail_unless (n_proplist_match_exact (receivedParams, proplist) == TRUE);
+    ck_assert (receivedParams != NULL);
+    ck_assert (n_proplist_match_exact (receivedParams, proplist) == TRUE);
     
     n_proplist_free (proplist);
     proplist = NULL;
@@ -76,34 +76,34 @@ START_TEST (test_register_sink)
     };
     NPlugin *plugin = NULL;
     plugin = g_new0 (NPlugin, 1);
-    fail_unless (plugin != NULL);
+    ck_assert (plugin != NULL);
     NCore *core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     plugin->core = core;
     int size = -1;
     
     n_plugin_register_sink (NULL, &decl);
     size = core->num_sinks;
-    fail_unless (size == 0);
+    ck_assert (size == 0);
     n_plugin_register_sink (plugin, NULL);
     size = core->num_sinks;
-    fail_unless (size == 0);
+    ck_assert (size == 0);
     
     /* tests for core -> get sink */
-    fail_unless (n_core_get_sinks (NULL) == NULL);
-    fail_unless (n_core_get_sinks (core) == NULL);
+    ck_assert (n_core_get_sinks (NULL) == NULL);
+    ck_assert (n_core_get_sinks (core) == NULL);
     
     /* register sink */
     n_plugin_register_sink (plugin, &decl);
     size = core->num_sinks;
-    fail_unless (size == 1);
+    ck_assert (size == 1);
 
     /* tests for core -> get sink */
     NSinkInterface **ifacev = NULL;
     ifacev = n_core_get_sinks (core);
-    fail_unless (ifacev != NULL);
+    ck_assert (ifacev != NULL);
     NSinkInterface *iface = ifacev[0];
-    fail_unless (g_strcmp0 (iface->name, decl.name) == 0);
+    ck_assert (g_strcmp0 (iface->name, decl.name) == 0);
 
     n_core_free (core);
     core = NULL;
@@ -123,23 +123,23 @@ START_TEST (test_register_input)
     };
     NPlugin *plugin = NULL;
     plugin = g_new0 (NPlugin, 1);
-    fail_unless (plugin != NULL);
+    ck_assert (plugin != NULL);
     NCore *core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     plugin->core = core;
     int size = -1;
     
     n_plugin_register_input (NULL, &decl);
     size = core->num_inputs;
-    fail_unless (size == 0);
+    ck_assert (size == 0);
     n_plugin_register_input (plugin, NULL);
     size = core->num_inputs;
-    fail_unless (size == 0);
+    ck_assert (size == 0);
     
     /* register input */
     n_plugin_register_input (plugin, &decl);
     size = core->num_inputs;
-    fail_unless (size == 1);
+    ck_assert (size == 1);
     
     n_core_free (core);
     core = NULL;
@@ -151,7 +151,7 @@ END_TEST
 START_TEST (test_load_plugin)
 {
     NCore *core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
 
     /* allow execution inside build tree */
     const char *build_tree_plugin_path = "./libngfd_test_fake.la";
@@ -165,35 +165,35 @@ START_TEST (test_load_plugin)
     NPlugin *loaded_plugin = NULL;
     /* try to load not existing plugin file */
     loaded_plugin = n_plugin_open ("./not_existing_plugin.la");
-    fail_unless (loaded_plugin == NULL);
+    ck_assert (loaded_plugin == NULL);
     /* load dummyu plugin file - valid one*/
     loaded_plugin = n_plugin_open (plugin_path);
-    fail_unless (loaded_plugin != NULL);
-    fail_unless (loaded_plugin->module != NULL);
+    ck_assert (loaded_plugin != NULL);
+    ck_assert (loaded_plugin->module != NULL);
     loaded_plugin->core = core;
     loaded_plugin->params = n_proplist_new ();
 
     /* load actual plugin */
     int result = loaded_plugin->load (loaded_plugin);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     const char *name = "test-fake";
-    fail_unless (g_strcmp0 (name, loaded_plugin->get_name ()) == 0);
+    ck_assert (g_strcmp0 (name, loaded_plugin->get_name ()) == 0);
     const char *desc = "Fake plugin for unit test purposes";
-    fail_unless (g_strcmp0 (desc, loaded_plugin->get_desc ()) == 0);
+    ck_assert (g_strcmp0 (desc, loaded_plugin->get_desc ()) == 0);
     const char *version = "0.1";
-    fail_unless (g_strcmp0 (version, loaded_plugin->get_version ()) == 0);
+    ck_assert (g_strcmp0 (version, loaded_plugin->get_version ()) == 0);
 
     int size = -1;
     size = core->num_sinks;
-    fail_unless (size == 1);
+    ck_assert (size == 1);
 
     /* tests for core -> get sink */
     NSinkInterface **ifacev = NULL;
     ifacev = n_core_get_sinks (core);
-    fail_unless (ifacev != NULL);
+    ck_assert (ifacev != NULL);
     NSinkInterface *iface = ifacev[0];
-    fail_unless (g_strcmp0 (iface->name, "fake") == 0);
+    ck_assert (g_strcmp0 (iface->name, "fake") == 0);
 
     /* call unload for specific plugin */
     loaded_plugin->unload (loaded_plugin);

--- a/tests/test-proplist.c
+++ b/tests/test-proplist.c
@@ -413,7 +413,6 @@ START_TEST (test_set_get_unset)
 
     n_proplist_free (proplist);
     proplist = NULL;
-    n_value_free (value);
     value = NULL;
 }
 END_TEST

--- a/tests/test-proplist.c
+++ b/tests/test-proplist.c
@@ -9,29 +9,29 @@ START_TEST (test_match_exact)
 {
     NProplist *proplistA = NULL;
     proplistA = n_proplist_new ();
-    fail_unless (proplistA != NULL);
+    ck_assert (proplistA != NULL);
     NProplist *proplistB = NULL;
     proplistB = n_proplist_new ();
-    fail_unless (proplistB != NULL);
+    ck_assert (proplistB != NULL);
     const char* key1 = "key1";
     const char* key2 = "key2";
 
     gboolean result = n_proplist_match_exact (NULL, proplistB);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     result = n_proplist_match_exact (proplistA, NULL);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 
     n_proplist_set_int (proplistA, key1, 100);
     result = n_proplist_match_exact (proplistA, proplistB);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     n_proplist_set_int (proplistB, key1, 100);
     result = n_proplist_match_exact (proplistA, proplistB);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     n_proplist_set_bool (proplistA, key2, TRUE);
     n_proplist_set_bool (proplistB, key2, FALSE);
     result = n_proplist_match_exact (proplistA, proplistB);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 
     n_proplist_free (proplistA);
     proplistA = NULL;
@@ -45,19 +45,19 @@ START_TEST (test_copy)
 {
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     NProplist *copy = NULL;
     copy = n_proplist_copy (NULL);
-    fail_unless (copy == NULL);
+    ck_assert (copy == NULL);
     copy = n_proplist_copy (proplist);
-    fail_unless (copy != NULL);
-    fail_unless (n_proplist_match_exact (proplist, copy) == TRUE);
+    ck_assert (copy != NULL);
+    ck_assert (n_proplist_match_exact (proplist, copy) == TRUE);
     n_proplist_set_int (proplist, "key", 100);
     n_proplist_free (copy);
     copy = NULL;
     copy = n_proplist_copy (proplist);
-    fail_unless (copy != NULL);
-    fail_unless (n_proplist_match_exact (proplist, copy) == TRUE);
+    ck_assert (copy != NULL);
+    ck_assert (n_proplist_match_exact (proplist, copy) == TRUE);
     
     n_proplist_free (copy);
     copy = NULL;
@@ -70,12 +70,12 @@ START_TEST (test_copy_keys)
 {
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     NProplist *keys = NULL;
     GList *list = NULL;
     keys = n_proplist_copy_keys (proplist, list);
-    fail_unless (keys != NULL);
-    fail_unless (n_proplist_is_empty (keys) == TRUE);
+    ck_assert (keys != NULL);
+    ck_assert (n_proplist_is_empty (keys) == TRUE);
     n_proplist_free (keys);
     keys = NULL;
 	    
@@ -85,28 +85,28 @@ START_TEST (test_copy_keys)
     list = g_list_append (list, (gpointer)key2);
 
     keys = n_proplist_copy_keys (NULL, list);
-    fail_unless (keys != NULL);
-    fail_unless (n_proplist_is_empty (keys) == TRUE);
+    ck_assert (keys != NULL);
+    ck_assert (n_proplist_is_empty (keys) == TRUE);
     n_proplist_free (keys);
     keys = NULL;
     keys = n_proplist_copy_keys (proplist, NULL);
-    fail_unless (keys != NULL);
-    fail_unless (n_proplist_is_empty (keys) == TRUE);
+    ck_assert (keys != NULL);
+    ck_assert (n_proplist_is_empty (keys) == TRUE);
     n_proplist_free (keys);
     keys = NULL;
 
     keys = n_proplist_copy_keys (proplist, list);
-    fail_unless (keys != NULL);
-    fail_unless (n_proplist_is_empty (keys) == TRUE);
+    ck_assert (keys != NULL);
+    ck_assert (n_proplist_is_empty (keys) == TRUE);
     n_proplist_set_bool (proplist, key1, FALSE);
     n_proplist_set_uint (proplist, key2, val_key2);
     n_proplist_free (keys);
     keys = NULL;
     keys = n_proplist_copy_keys (proplist, list);
-    fail_unless (keys != NULL);
-    fail_unless (n_proplist_is_empty (keys) == FALSE);
-    fail_unless (n_proplist_size (keys) == 1);
-    fail_unless (n_proplist_get_uint (keys, key2) == val_key2);
+    ck_assert (keys != NULL);
+    ck_assert (n_proplist_is_empty (keys) == FALSE);
+    ck_assert (n_proplist_size (keys) == 1);
+    ck_assert (n_proplist_get_uint (keys, key2) == val_key2);
     
     g_list_free (list);
     list = NULL;
@@ -122,10 +122,10 @@ START_TEST (test_merge)
 {
     NProplist *source = NULL;
     source = n_proplist_new ();
-    fail_unless (source != NULL);
+    ck_assert (source != NULL);
     NProplist *target = NULL;
     target = n_proplist_new ();
-    fail_unless (target != NULL);
+    ck_assert (target != NULL);
     static char* keys[] = {"key1", "key2", "key3", "key4", "key5"};
     uint i = 0;
     for (i = 0; i < ARRAY_SIZE (keys); i++)
@@ -144,14 +144,14 @@ START_TEST (test_merge)
     NProplist *sourceCopy = n_proplist_copy (source);
     
     n_proplist_merge (NULL, source);
-    fail_unless (n_proplist_has_key (target, new_key) == FALSE);
-    fail_unless (n_proplist_match_exact (target, targetCopy) == TRUE);
-    fail_unless (n_proplist_match_exact (source, sourceCopy) == TRUE);
+    ck_assert (n_proplist_has_key (target, new_key) == FALSE);
+    ck_assert (n_proplist_match_exact (target, targetCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (source, sourceCopy) == TRUE);
     
     n_proplist_merge (target, NULL);
-    fail_unless (n_proplist_has_key (target, new_key) == FALSE);
-    fail_unless (n_proplist_match_exact (target, targetCopy) == TRUE);
-    fail_unless (n_proplist_match_exact (source, sourceCopy) == TRUE);
+    ck_assert (n_proplist_has_key (target, new_key) == FALSE);
+    ck_assert (n_proplist_match_exact (target, targetCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (source, sourceCopy) == TRUE);
     
 
     /* Two keys are common (will be replaces),
@@ -161,13 +161,13 @@ START_TEST (test_merge)
     n_proplist_merge (target, source);
     //n_proplist_foreach (target, listing, NULL);
     
-    fail_unless (n_proplist_match_exact (target, targetCopy) == FALSE);
-    fail_unless (n_proplist_match_exact (source, sourceCopy) == TRUE);
-    fail_unless (n_proplist_size (target) == ARRAY_SIZE (keys) + 1);
+    ck_assert (n_proplist_match_exact (target, targetCopy) == FALSE);
+    ck_assert (n_proplist_match_exact (source, sourceCopy) == TRUE);
+    ck_assert (n_proplist_size (target) == ARRAY_SIZE (keys) + 1);
     const char *merged1 = n_proplist_get_string (target, merge_key1);
-    fail_unless (g_strcmp0 (key1_value, merged1) == 0);
+    ck_assert (g_strcmp0 (key1_value, merged1) == 0);
     int merged2 = n_proplist_get_int (target, merge_key2);
-    fail_unless (merged2 == ARRAY_SIZE (keys));
+    ck_assert (merged2 == ARRAY_SIZE (keys));
     
     n_proplist_free (sourceCopy);
     sourceCopy = NULL;
@@ -194,10 +194,10 @@ START_TEST (test_merge_keys)
 {
     NProplist *source = NULL;
     source = n_proplist_new ();
-    fail_unless (source != NULL);   
+    ck_assert (source != NULL);
     NProplist *target = NULL;
     target = n_proplist_new ();
-    fail_unless (target != NULL);
+    ck_assert (target != NULL);
 
     /* keys and values at the same time */
     static char* keys[] = {"key1", "key2", "key3", "key4",
@@ -228,30 +228,30 @@ START_TEST (test_merge_keys)
     NProplist *targetCopy = n_proplist_copy (target);
     
     n_proplist_merge_keys (NULL, source, list);
-    fail_unless (n_proplist_match_exact (source, sourceCopy) == TRUE);
-    fail_unless (n_proplist_match_exact (target, targetCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (source, sourceCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (target, targetCopy) == TRUE);
     
     n_proplist_merge_keys (target, NULL, list);
-    fail_unless (n_proplist_match_exact (source, sourceCopy) == TRUE);
-    fail_unless (n_proplist_match_exact (target, targetCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (source, sourceCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (target, targetCopy) == TRUE);
     
     /* copy of target proplist to check merge_keys with NULL GList = normal merge in the next line */
     NProplist *secondTarget = n_proplist_copy (target);
     /* first half of seconfTarget will be fill with ints from source */
     n_proplist_merge_keys (secondTarget, source, NULL);
     //n_proplist_foreach (secondTarget, listing, NULL);
-    fail_unless (n_proplist_match_exact (target, secondTarget) == FALSE);
+    ck_assert (n_proplist_match_exact (target, secondTarget) == FALSE);
     for (i = 0; i < ARRAY_SIZE (keys); i++)
     {
         if (i < ARRAY_SIZE (keys) / 2)
         {
             int result = n_proplist_get_int (secondTarget, keys[i]);
-            fail_unless (result == i_values[i]);
+            ck_assert (result == i_values[i]);
         }
         else
         {
             const char *result = n_proplist_get_string (secondTarget, keys[i]);
-            fail_unless (g_strcmp0 (result, keys[i]) == 0);
+            ck_assert (g_strcmp0 (result, keys[i]) == 0);
         }
     }
     
@@ -259,20 +259,20 @@ START_TEST (test_merge_keys)
      * first 1/4 of the elements from target will be int type */
     n_proplist_merge_keys (target, source, list);
     //n_proplist_foreach (target, listing, NULL);
-    fail_unless (n_proplist_match_exact (target, targetCopy) == FALSE);
-    fail_unless (n_proplist_match_exact (source, sourceCopy) == TRUE);
+    ck_assert (n_proplist_match_exact (target, targetCopy) == FALSE);
+    ck_assert (n_proplist_match_exact (source, sourceCopy) == TRUE);
 
     for (i = 0; i < ARRAY_SIZE (keys); i++)
     {
         if (i < n_list)
 	{
             int result = n_proplist_get_int (target, keys[i]);
-            fail_unless (result == i_values[i]);
+            ck_assert (result == i_values[i]);
 	}
 	else
 	{
             const char *result = n_proplist_get_string (target, keys[i]);
-	    fail_unless (g_strcmp0 (result, keys[i]) == 0);
+        ck_assert (g_strcmp0 (result, keys[i]) == 0);
 	}
     }
     
@@ -294,14 +294,14 @@ START_TEST (test_size)
     const char *key = "ngf";
     NProplist *proplist = NULL;
     int size = n_proplist_size (proplist);
-    fail_unless (size == 0);
+    ck_assert (size == 0);
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     size = n_proplist_size (proplist);
-    fail_unless (size == 0);
+    ck_assert (size == 0);
     n_proplist_set_pointer (proplist, key, proplist);
     size = n_proplist_size (proplist);
-    fail_unless (size == 1);
+    ck_assert (size == 1);
 
     n_proplist_free (proplist);
     proplist = NULL;
@@ -321,13 +321,13 @@ START_TEST (test_foreach)
 {
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     uint i = 0, check_n = 0;
     char* keys[] = { "random", "data", "keys"};
     for (i = 0; i < ARRAY_SIZE (keys); i++)
         n_proplist_set_string (proplist, keys[i], keys[i]);
     n_proplist_foreach (proplist, n_proplist_Callback, &check_n);
-    fail_unless (check_n == ARRAY_SIZE (keys));
+    ck_assert (check_n == ARRAY_SIZE (keys));
 
     n_proplist_free (proplist);
     proplist = NULL;
@@ -339,14 +339,14 @@ START_TEST (test_is_empty)
     const char *key = "ngf";
     NProplist *proplist = NULL;
     gboolean result = n_proplist_is_empty (proplist);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     result = n_proplist_is_empty (proplist);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     n_proplist_set_pointer (proplist, key, proplist);
     result = n_proplist_is_empty (proplist);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 
     n_proplist_free (proplist);
     proplist = NULL;
@@ -357,18 +357,18 @@ START_TEST (test_has_key)
 {
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     const char *key = "key";
     gboolean result = n_proplist_has_key (proplist, key);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
     result = n_proplist_has_key (NULL, key);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 //    result = n_proplist_has_key (proplist, NULL);
-//    fail_unless (result == FALSE);
+//    ck_assert (result == FALSE);
     
     n_proplist_set_int (proplist, key, 100);
     result = n_proplist_has_key (proplist, key);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     n_proplist_free (proplist);
     proplist = NULL;
@@ -379,7 +379,7 @@ START_TEST (test_set_get_unset)
 {
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     NValue *value = NULL;
     value = n_value_new ();
     n_value_set_int (value, 100);
@@ -387,29 +387,29 @@ START_TEST (test_set_get_unset)
     const char *key = "key";
     
     n_proplist_set (NULL, key, value);
-    fail_unless (n_proplist_is_empty (proplist) == TRUE);
+    ck_assert (n_proplist_is_empty (proplist) == TRUE);
     n_proplist_set (proplist, NULL, value);
-    fail_unless (n_proplist_is_empty (proplist) == TRUE);
+    ck_assert (n_proplist_is_empty (proplist) == TRUE);
     n_proplist_set (proplist, key, NULL);
-    fail_unless (n_proplist_is_empty (proplist) == TRUE);
+    ck_assert (n_proplist_is_empty (proplist) == TRUE);
     n_proplist_set (proplist, key, value);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
 
     result = n_proplist_get (NULL, key);
-    fail_unless (result == NULL);
+    ck_assert (result == NULL);
     result = n_proplist_get (proplist, NULL);
-    fail_unless (result == NULL);
+    ck_assert (result == NULL);
     result = n_proplist_get (proplist, key);
-    fail_unless (result == value);
-    fail_unless (n_value_equals (result, value) == TRUE);
+    ck_assert (result == value);
+    ck_assert (n_value_equals (result, value) == TRUE);
 
     n_proplist_unset (NULL, key);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     n_proplist_unset (proplist, NULL);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     n_proplist_unset (proplist, key);
-    fail_unless (n_proplist_is_empty (proplist) == TRUE);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_is_empty (proplist) == TRUE);
+    ck_assert (n_proplist_size (proplist) == 0);
 
     n_proplist_free (proplist);
     proplist = NULL;
@@ -422,30 +422,30 @@ START_TEST (test_proplist_values)
 {
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     const char *key = "ngf";
     const char *value_str = "ValuE";
 
     /* string */    
     n_proplist_set_string (NULL, key, value_str);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     n_proplist_set_string (proplist, NULL, value_str);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     n_proplist_set_string (proplist, key, NULL);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
 
     n_proplist_set_string (proplist, key, value_str);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     const char *result_str = n_proplist_get_string (proplist, key);
-    fail_unless (result_str != NULL);
-    fail_unless (g_strcmp0 (result_str, value_str) == 0);
-    fail_unless (n_proplist_get_string (NULL, key) == NULL);
-    fail_unless (n_proplist_get_string (proplist, NULL) == NULL);
+    ck_assert (result_str != NULL);
+    ck_assert (g_strcmp0 (result_str, value_str) == 0);
+    ck_assert (n_proplist_get_string (NULL, key) == NULL);
+    ck_assert (n_proplist_get_string (proplist, NULL) == NULL);
 
     /* duplicate string */
     char *duplicate = n_proplist_dup_string (proplist, key);
-    fail_unless (duplicate != NULL);
-    fail_unless (g_strcmp0 (duplicate, value_str) == 0);
+    ck_assert (duplicate != NULL);
+    ck_assert (g_strcmp0 (duplicate, value_str) == 0);
 
     n_proplist_free (proplist);
     proplist = NULL;
@@ -453,83 +453,83 @@ START_TEST (test_proplist_values)
     duplicate = NULL;
 
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     int value = -100;
 
     /* int */
     n_proplist_set_int (NULL, key, value);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     n_proplist_set_int (proplist, NULL, value);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
 
     n_proplist_set_int (proplist, key, value);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     int result_int = n_proplist_get_int (proplist, key);
-    fail_unless (result_int == value);
-    fail_unless (n_proplist_get_int (NULL, key) == 0);
-    fail_unless (n_proplist_get_int (proplist, NULL) == 0);
+    ck_assert (result_int == value);
+    ck_assert (n_proplist_get_int (NULL, key) == 0);
+    ck_assert (n_proplist_get_int (proplist, NULL) == 0);
 
     n_proplist_free (proplist);
     proplist = NULL;
 
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     uint value_uint = 100;
 
     /* uint */
     n_proplist_set_uint (NULL, key, value_uint);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     n_proplist_set_uint (proplist, NULL, value_uint);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     
     n_proplist_set_uint (proplist, key, value_uint);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     uint result_uint = n_proplist_get_uint (proplist, key);
-    fail_unless (result_uint == value_uint);
-    fail_unless (n_proplist_get_uint (NULL, key) == 0);
-    fail_unless (n_proplist_get_uint (proplist, NULL) == 0);
+    ck_assert (result_uint == value_uint);
+    ck_assert (n_proplist_get_uint (NULL, key) == 0);
+    ck_assert (n_proplist_get_uint (proplist, NULL) == 0);
 
     n_proplist_free (proplist);
     proplist = NULL;
     
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     gboolean value_bool = TRUE;
 
     /* bool */
     n_proplist_set_bool (NULL, key, value_bool);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     n_proplist_set_bool (proplist, NULL, value_bool);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     
     n_proplist_set_bool (proplist, key, value_bool);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     gboolean result_bool = n_proplist_get_bool (proplist, key);
-    fail_unless (result_bool == value_bool);
-    fail_unless (n_proplist_get_bool (NULL, key) == FALSE);
-    fail_unless (n_proplist_get_bool (proplist, NULL) == FALSE);
+    ck_assert (result_bool == value_bool);
+    ck_assert (n_proplist_get_bool (NULL, key) == FALSE);
+    ck_assert (n_proplist_get_bool (proplist, NULL) == FALSE);
 
     n_proplist_free (proplist);
     proplist = NULL;
     
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     gpointer value_gpointer = proplist;
     
     /* gpointer */
     n_proplist_set_pointer (NULL, key, value_gpointer);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
     n_proplist_set_pointer (proplist, NULL, value_gpointer);
-    fail_unless (n_proplist_size (proplist) == 0);
+    ck_assert (n_proplist_size (proplist) == 0);
 //    n_proplist_set_pointer (proplist, key, NULL);
-//    fail_unless (n_proplist_size (proplist) == 0);
+//    ck_assert (n_proplist_size (proplist) == 0);
     
     n_proplist_set_pointer (proplist, key, value_gpointer);
-    fail_unless (n_proplist_size (proplist) == 1);
+    ck_assert (n_proplist_size (proplist) == 1);
     gpointer result_gpointer = n_proplist_get_pointer (proplist, key);
-    fail_unless (result_gpointer == value_gpointer);
-    fail_unless (n_proplist_get_pointer (NULL, key) == 0);
-    fail_unless (n_proplist_get_pointer (proplist, NULL) == 0);
+    ck_assert (result_gpointer == value_gpointer);
+    ck_assert (n_proplist_get_pointer (NULL, key) == 0);
+    ck_assert (n_proplist_get_pointer (proplist, NULL) == 0);
 
     n_proplist_free (proplist);
     proplist = NULL;

--- a/tests/test-request.c
+++ b/tests/test-request.c
@@ -8,17 +8,17 @@ START_TEST (test_create)
 {
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
-    fail_unless (n_request_get_name (request) == NULL);
+    ck_assert (request != NULL);
+    ck_assert (n_request_get_name (request) == NULL);
     n_request_free (request);
     request = NULL;
 
     /* create request with event name */
     const char *event = "event";
     request = n_request_new_with_event (event);
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *name = n_request_get_name (request);
-    fail_unless (g_strcmp0 (name, event) == 0);
+    ck_assert (g_strcmp0 (name, event) == 0);
     n_request_free (request);
     request = NULL;
 
@@ -26,22 +26,22 @@ START_TEST (test_create)
     const char *key = "key";
     int value = -100;
     NProplist *proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_proplist_set_int (proplist, key, value);
     request = n_request_new_with_event_and_properties (NULL, proplist);
-    fail_unless (request == NULL);
+    ck_assert (request == NULL);
     request = n_request_new_with_event_and_properties (event, NULL);
-    fail_unless (request != NULL);
-    fail_unless (n_request_get_properties (request) == NULL);
+    ck_assert (request != NULL);
+    ck_assert (n_request_get_properties (request) == NULL);
     n_request_free (request);
     request = NULL;
     
     request = n_request_new_with_event_and_properties (event, proplist);
     const NProplist *set = n_request_get_properties (request);
-    fail_unless (n_proplist_match_exact (set, proplist) == TRUE);
+    ck_assert (n_proplist_match_exact (set, proplist) == TRUE);
     name = NULL;
     name = n_request_get_name (request);
-    fail_unless (g_strcmp0 (name, event) == 0);
+    ck_assert (g_strcmp0 (name, event) == 0);
     
     n_proplist_free (proplist);
     proplist = NULL;
@@ -54,33 +54,33 @@ START_TEST (test_properties)
 {
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     NProplist *proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     const char *key = "key";
     /* set pointer to proplist */
     n_proplist_set_pointer (proplist, key, (gpointer)request);
     /* get properties from NULL request */
-    fail_unless (n_request_get_properties (NULL) == NULL);
+    ck_assert (n_request_get_properties (NULL) == NULL);
     
     n_request_set_properties (NULL, proplist);
-    fail_unless (n_request_get_properties (request) == NULL);
+    ck_assert (n_request_get_properties (request) == NULL);
     
     n_request_set_properties (request, NULL);
-    fail_unless (n_request_get_properties (request) == NULL);
+    ck_assert (n_request_get_properties (request) == NULL);
     
     n_request_set_properties (request, proplist);
     const NProplist *set = n_request_get_properties (request);
-    fail_unless (n_proplist_match_exact (set, proplist) == TRUE);
+    ck_assert (n_proplist_match_exact (set, proplist) == TRUE);
 
     n_request_set_properties (NULL, proplist);
     set = NULL;
     set = n_request_get_properties (request);
-    fail_unless (n_proplist_match_exact (set, proplist) == TRUE);
+    ck_assert (n_proplist_match_exact (set, proplist) == TRUE);
     n_request_set_properties (request, NULL);
     set = NULL;
     set = n_request_get_properties (request);
-    fail_unless (n_proplist_match_exact (set, proplist) == TRUE);
+    ck_assert (n_proplist_match_exact (set, proplist) == TRUE);
     
     n_proplist_free (proplist);
     proplist = NULL;
@@ -93,30 +93,30 @@ START_TEST (test_data)
 {
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *key = "key";
     NProplist *proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_request_set_properties (request, proplist);
     n_proplist_free (proplist);
     proplist = NULL;
 
-    fail_unless (n_request_get_data (NULL, key) == NULL);
-    fail_unless (n_request_get_data (request, NULL) == NULL);
-    fail_unless (n_request_get_data (request, key) == NULL);
+    ck_assert (n_request_get_data (NULL, key) == NULL);
+    ck_assert (n_request_get_data (request, NULL) == NULL);
+    ck_assert (n_request_get_data (request, key) == NULL);
 
     void *data;
     n_request_store_data (NULL, key, request);
     data = n_request_get_data (request, key);
-    fail_unless (data == NULL);
+    ck_assert (data == NULL);
     n_request_store_data (request, NULL, request);
     data = n_request_get_data (request, key);
-    fail_unless (data == NULL);
+    ck_assert (data == NULL);
     n_request_store_data (request, key, request);
     /* verification */
     data = n_request_get_data (request, key);
-    fail_unless (data != NULL);
-    fail_unless (data == request);
+    ck_assert (data != NULL);
+    ck_assert (data == request);
 
     n_request_free (request);
     request = NULL;

--- a/tests/test-sinkinterface.c
+++ b/tests/test-sinkinterface.c
@@ -12,14 +12,14 @@ START_TEST (test_get_core_and_name)
 {
     NSinkInterface *iface = NULL;
     iface = g_new0 (NSinkInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     
-    fail_unless (n_sink_interface_get_core (NULL) == NULL);
-    fail_unless (n_sink_interface_get_name (NULL) == NULL);
+    ck_assert (n_sink_interface_get_core (NULL) == NULL);
+    ck_assert (n_sink_interface_get_name (NULL) == NULL);
 
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     core->conf_path = g_strdup ("path");
     iface->core = core;
 
@@ -27,12 +27,12 @@ START_TEST (test_get_core_and_name)
     iface->name = name;
 
     const char *receivedName = n_sink_interface_get_name (iface);
-    fail_unless (receivedName != NULL);
-    fail_unless (g_strcmp0 (receivedName, name) == 0);
+    ck_assert (receivedName != NULL);
+    ck_assert (g_strcmp0 (receivedName, name) == 0);
 
     NCore *receivedCore = n_sink_interface_get_core (iface);
-    fail_unless (receivedCore != NULL);
-    fail_unless (g_strcmp0 (core->conf_path, receivedCore->conf_path) == 0);
+    ck_assert (receivedCore != NULL);
+    ck_assert (g_strcmp0 (core->conf_path, receivedCore->conf_path) == 0);
     
     n_core_free (core);
     core = NULL;
@@ -45,38 +45,38 @@ START_TEST (test_resync_on_master)
 {
     NSinkInterface *iface = NULL;
     iface = g_new0 (NSinkInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     const char *name = "TEST_RESYNC_ON_MASTER_sink_name";
     iface->name = name;
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *req_name = "TEST_RESYNC_ON_MASTER_REQUST_name";
     request->name = g_strdup (req_name);
     request->sinks_resync = NULL;
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     iface->core = core;
     request->core = core;
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_request_set_properties (request, proplist);
     n_proplist_free (proplist);
     proplist = NULL;
 
     /* test for invalid parameter */
     n_sink_interface_set_resync_on_master (NULL, request);
-    fail_unless (request->sinks_resync == NULL);
+    ck_assert (request->sinks_resync == NULL);
     /* test for invalid parameter */
     n_sink_interface_set_resync_on_master (iface, NULL);
-    fail_unless (request->sinks_resync == NULL);
+    ck_assert (request->sinks_resync == NULL);
 
     /* master_sink = sink */
     request->master_sink = iface;
     n_sink_interface_set_resync_on_master (iface, request);
-    fail_unless (request->sinks_resync == NULL);
+    ck_assert (request->sinks_resync == NULL);
 
     
     request->master_sink = NULL;
@@ -87,14 +87,14 @@ START_TEST (test_resync_on_master)
     
     /* add proper sink do resync sinks */
     n_sink_interface_set_resync_on_master (iface, request);
-    fail_unless (request->sinks_resync != NULL);
-    fail_unless (g_list_length (request->sinks_resync) == 1);
-    fail_unless (g_list_find (request->sinks_resync, iface) != NULL);
+    ck_assert (request->sinks_resync != NULL);
+    ck_assert (g_list_length (request->sinks_resync) == 1);
+    ck_assert (g_list_find (request->sinks_resync, iface) != NULL);
 
     /* readd sink that is already synced */
     n_sink_interface_set_resync_on_master (iface, request);
-    fail_unless (request->sinks_resync != NULL);
-    fail_unless (g_list_length (request->sinks_resync) == 1);
+    ck_assert (request->sinks_resync != NULL);
+    ck_assert (g_list_length (request->sinks_resync) == 1);
 
     g_free (master_sink);
     master_sink = NULL;
@@ -135,55 +135,55 @@ START_TEST (test_resynchronize)
 {
     NSinkInterface *iface = NULL;
     iface = g_new0 (NSinkInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     const char *name = "TEST_RESYNC_sink_name";
     iface->name = name;
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *req_name = "TEST_RESYNC_REQUST_name";
     request->name = g_strdup (req_name);
     request->sinks_preparing = NULL;
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     iface->core = core;
     request->core = core;
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_request_set_properties (request, proplist);
     n_proplist_free (proplist);
     proplist = NULL;
 
     /* test for invelid parameter */
     n_sink_interface_resynchronize (NULL, request);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
     /* test for invalid parameter */
     n_sink_interface_resynchronize (iface, NULL);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
     /* sink (iface) is not master sink */
     n_sink_interface_resynchronize (iface, request);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
 
     request->play_source_id = 100;
     request->master_sink = iface;
     /* play_source_id > 0 */
     n_sink_interface_resynchronize (iface, request);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
     /* needs verification */
 
     request->sinks_playing = g_list_append (request->sinks_playing, iface);
     request->play_source_id = 0;
     /* sink_resync is NULL */
     n_sink_interface_resynchronize (iface, request);
-    fail_unless (request->sinks_playing == NULL);
-    fail_unless (request->sinks_prepared != NULL);
-    fail_unless (request->play_source_id == 1);
+    ck_assert (request->sinks_playing == NULL);
+    ck_assert (request->sinks_prepared != NULL);
+    ck_assert (request->play_source_id == 1);
 
     request->play_source_id = 0;
     NSinkInterface *sink_in_resync = g_new0 (NSinkInterface, 1);
-    fail_unless (sink_in_resync != NULL);
+    ck_assert (sink_in_resync != NULL);
     const char *sink_name = "TEST_RESYNC_sink_name";
     sink_in_resync->name = sink_name;
     static const NSinkInterfaceDecl decl = {
@@ -207,10 +207,10 @@ START_TEST (test_resynchronize)
      * */
 
     int *data = (int*) n_request_get_data (request, DATA_KEY);
-    fail_unless (data != NULL);
-    fail_unless (*data == 1);
-    fail_unless (request->sinks_resync == NULL);
-    fail_unless (g_list_find (request->sinks_preparing, sink_in_resync) != NULL);
+    ck_assert (data != NULL);
+    ck_assert (*data == 1);
+    ck_assert (request->sinks_resync == NULL);
+    ck_assert (g_list_find (request->sinks_preparing, sink_in_resync) != NULL);
 
     g_slice_free (int, data);
     data = NULL;
@@ -231,53 +231,53 @@ START_TEST (test_synchronize)
 {
     NSinkInterface *iface = NULL;
     iface = g_new0 (NSinkInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     const char *name = "TEST_SYNCHRONIZE_sink_name";
     iface->name = name;
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *req_name = "TEST_SYNCHRONIZE_REQUST_name";
     request->name = g_strdup (req_name);
     request->sinks_preparing = NULL;
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     iface->core = core;
     request->core = core;
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_request_set_properties (request, proplist);
     n_proplist_free (proplist);
     proplist = NULL;
 
     /* test for invalid parameter */
     n_sink_interface_synchronize (NULL, request);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
     /* test for invalid parameter */
     n_sink_interface_synchronize (iface, NULL);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
 
     /* request->sinks_preparing is NULL */
     n_sink_interface_synchronize (iface, request);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (request->sinks_prepared == NULL);
 
     NSinkInterface *iface_second = g_new0 (NSinkInterface, 1);
     /* add different sink (iface_second) to preparing list */
     request->sinks_preparing = g_list_append (request->sinks_preparing, iface_second);
     /* sink (iface_second) is already in preparing phase, but we call sync for iface */
     n_sink_interface_synchronize (iface, request);
-    fail_unless (g_list_length (request->sinks_preparing) == 1);
-    fail_unless (request->sinks_prepared == NULL);
+    ck_assert (g_list_length (request->sinks_preparing) == 1);
+    ck_assert (request->sinks_prepared == NULL);
 
     /* add proper sink to preparing list, at that point two items are in the preparing list */
     request->sinks_preparing = g_list_append (request->sinks_preparing, iface);
     n_sink_interface_synchronize (iface, request);
-    fail_unless (g_list_length (request->sinks_preparing) == 1);
-    fail_unless (request->sinks_prepared != NULL);
-    fail_unless (g_list_length (request->sinks_prepared) == 1);
-    fail_unless (g_list_find (request->sinks_prepared, iface) != NULL);
+    ck_assert (g_list_length (request->sinks_preparing) == 1);
+    ck_assert (request->sinks_prepared != NULL);
+    ck_assert (g_list_length (request->sinks_prepared) == 1);
+    ck_assert (g_list_find (request->sinks_prepared, iface) != NULL);
 
     g_free (iface_second);
     iface_second = NULL;
@@ -298,23 +298,23 @@ START_TEST (test_complete)
 {
     NSinkInterface *iface = NULL;
     iface = g_new0 (NSinkInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     const char *name = "TEST_COMPLETE_sink_name";
     iface->name = name;
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *req_name = "TEST_COMPLETE_REQUST_name";
     request->name = g_strdup (req_name);
     request->sinks_playing = NULL;
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     iface->core = core;
     request->core = core;
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_request_set_properties (request, proplist);
     n_proplist_free (proplist);
     proplist = NULL;
@@ -326,16 +326,16 @@ START_TEST (test_complete)
     request->sinks_playing = g_list_append (request->sinks_playing, iface);
     /* test for invalid parameters */
     n_sink_interface_complete (NULL, request);
-    fail_unless (request->sinks_playing != NULL);
-    fail_unless (g_list_length (request->sinks_playing) == 1);
+    ck_assert (request->sinks_playing != NULL);
+    ck_assert (g_list_length (request->sinks_playing) == 1);
     /* test for invalid parameters */
     n_sink_interface_complete (iface, NULL);
-    fail_unless (request->sinks_playing != NULL);
-    fail_unless (g_list_length (request->sinks_playing) == 1);
+    ck_assert (request->sinks_playing != NULL);
+    ck_assert (g_list_length (request->sinks_playing) == 1);
     
     n_sink_interface_complete (iface, request);
-    fail_unless (request->sinks_playing == NULL);
-    fail_unless (request->stop_source_id = 1);
+    ck_assert (request->sinks_playing == NULL);
+    ck_assert (request->stop_source_id = 1);
 
     n_core_free (core);
     core = NULL;
@@ -350,12 +350,12 @@ START_TEST (test_fail)
 {
     NSinkInterface *iface = NULL;
     iface = g_new0 (NSinkInterface, 1);
-    fail_unless (iface != NULL);
+    ck_assert (iface != NULL);
     const char *name = "TEST_FAIL_sink_name";
     iface->name = name;
     NRequest *request = NULL;
     request = n_request_new ();
-    fail_unless (request != NULL);
+    ck_assert (request != NULL);
     const char *req_name = "TEST_FAIL_REQUST_name";
     request->name = g_strdup (req_name);
     /* stop_source_id < 0 to go to the end of the function */
@@ -363,32 +363,32 @@ START_TEST (test_fail)
     request->has_failed = FALSE;
     NCore *core = NULL;
     core = n_core_new (NULL, NULL);
-    fail_unless (core != NULL);
+    ck_assert (core != NULL);
     iface->core = core;
     request->core = core;
     NProplist *proplist = NULL;
     proplist = n_proplist_new ();
-    fail_unless (proplist != NULL);
+    ck_assert (proplist != NULL);
     n_request_set_properties (request, proplist);
     n_proplist_free (proplist);
     proplist = NULL;
     
     /* test for invalid parameters */
     n_sink_interface_fail (NULL, request);
-    fail_unless (request->has_failed == FALSE);
+    ck_assert (request->has_failed == FALSE);
     /* test for invalid parametes */
     n_sink_interface_fail (iface, NULL);
-    fail_unless (request->has_failed == FALSE);
+    ck_assert (request->has_failed == FALSE);
     
     /* proper test */
     n_sink_interface_fail (iface, request);
-    fail_unless (request->has_failed == TRUE);
-    fail_unless (request->stop_source_id == 1);
+    ck_assert (request->has_failed == TRUE);
+    ck_assert (request->stop_source_id == 1);
     
     request->stop_source_id = 100;
     request->has_failed = FALSE;
     n_sink_interface_fail (iface, request);
-    fail_unless (request->has_failed == FALSE);
+    ck_assert (request->has_failed == FALSE);
 
     n_core_free (core);
     core = NULL;

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -7,19 +7,19 @@ START_TEST (test_value_create)
 {
     NValue *value = NULL;
     int type = n_value_type (value);
-    fail_unless (type == 0);
+    ck_assert (type == 0);
     value = n_value_new ();
-    fail_unless (value != NULL);
+    ck_assert (value != NULL);
 	
     /* set type to integer */
     n_value_set_int (value, 100);
     type = n_value_type (value);
-    fail_unless (type == N_VALUE_TYPE_INT);
+    ck_assert (type == N_VALUE_TYPE_INT);
 	
     /* set memory to 0 */
     n_value_init (value);
     type = n_value_type (value);
-    fail_unless (type == 0);
+    ck_assert (type == 0);
 
     n_value_free (value);
     value = NULL;
@@ -31,10 +31,10 @@ START_TEST (test_copy)
     NValue *val = NULL;
     NValue *copy = NULL;
     copy = n_value_copy (val);
-    fail_unless (copy == NULL);
+    ck_assert (copy == NULL);
     val = n_value_new ();
     copy = n_value_copy (val);
-    fail_unless (copy == NULL);
+    ck_assert (copy == NULL);
     gboolean result = FALSE;
     const char *str = "ngf";
 
@@ -42,7 +42,7 @@ START_TEST (test_copy)
     n_value_set_string (val, str);
     copy = n_value_copy (val);
     result = n_value_equals (val, copy);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     n_value_free (copy);
     copy = NULL;
 
@@ -50,7 +50,7 @@ START_TEST (test_copy)
     n_value_set_int (val, -10);
     copy = n_value_copy (val);
     result = n_value_equals (val, copy);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     n_value_free (copy);
     copy = NULL;
 
@@ -58,7 +58,7 @@ START_TEST (test_copy)
     n_value_set_uint (val, 10);
     copy = n_value_copy (val);
     result = n_value_equals (val, copy);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     n_value_free (copy);
     copy = NULL;
 
@@ -66,7 +66,7 @@ START_TEST (test_copy)
     n_value_set_bool (val, TRUE);
     copy = n_value_copy (val);
     result = n_value_equals (val, copy);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
     n_value_free (copy);
     copy = NULL;
 
@@ -74,7 +74,7 @@ START_TEST (test_copy)
     n_value_set_pointer(val, val);
     copy = n_value_copy (val);
     result = n_value_equals (val, copy);
-    fail_unless (result == TRUE);	
+    ck_assert (result == TRUE);
 	
     n_value_free (val);
     val = NULL;
@@ -91,7 +91,7 @@ START_TEST (test_equals)
 
     /* both are NULL */
     result = n_value_equals (valA, valB);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 
     valA = n_value_new ();
     valB = n_value_new ();
@@ -102,41 +102,41 @@ START_TEST (test_equals)
     n_value_set_uint (valB, 10);
     /* types differ */
     result = n_value_equals (valA, valB);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 	
     /* string types */
     n_value_set_string (valB, str);
     result = n_value_equals (valA, valB);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     /* int types */
     n_value_set_int (valA, -10);
     n_value_set_int (valB, -10);
     result = n_value_equals (valA, valB);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     /* uint types */
     n_value_set_uint (valA, 10);
     n_value_set_uint (valB, 10);
     result = n_value_equals (valA, valB);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     /* boolean types */
     n_value_set_bool (valA, TRUE);
     n_value_set_bool (valB, TRUE);
     result = n_value_equals (valA, valB);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     /* pointer types */
     n_value_set_pointer (valA, valA);
     n_value_set_pointer (valB, valA);
     result = n_value_equals (valA, valB);
-    fail_unless (result == TRUE);
+    ck_assert (result == TRUE);
 
     /* different poiter */
     n_value_set_pointer (valB, valB);
     result = n_value_equals (valA, valB);
-    fail_unless (result == FALSE);
+    ck_assert (result == FALSE);
 
     n_value_free (valA);
     valA = NULL;
@@ -149,14 +149,14 @@ START_TEST (test_string)
 {
     NValue *value = NULL;
     value = n_value_new ();
-    fail_unless (value != NULL);
-    fail_unless (n_value_get_string (value) == NULL);
+    ck_assert (value != NULL);
+    ck_assert (n_value_get_string (value) == NULL);
     const char *str_val = "NGF\0";
     n_value_set_string (value, str_val);
     const char *reply = n_value_get_string (value);
-    fail_unless (reply != str_val);
+    ck_assert (reply != str_val);
     char *duplicate = n_value_dup_string (value);
-    fail_unless (strcmp (duplicate, str_val) == 0);
+    ck_assert (strcmp (duplicate, str_val) == 0);
 	
     g_free (duplicate);
     duplicate = NULL;
@@ -169,12 +169,12 @@ START_TEST (test_int)
 {
     NValue *value = NULL;
     value = n_value_new ();
-    fail_unless (value != NULL);
-    fail_unless (n_value_get_string (value) == 0);
+    ck_assert (value != NULL);
+    ck_assert (n_value_get_string (value) == 0);
     int val = -100;
     n_value_set_int (value, val);
     int reply = n_value_get_int (value);
-    fail_unless (reply == val);
+    ck_assert (reply == val);
 
     n_value_free (value);
     value = NULL;
@@ -185,12 +185,12 @@ START_TEST (test_uint)
 {
     NValue *value = NULL;
     value = n_value_new ();
-    fail_unless (value != NULL);
-    fail_unless (n_value_get_uint (value) == 0);
+    ck_assert (value != NULL);
+    ck_assert (n_value_get_uint (value) == 0);
     uint val = 100;
     n_value_set_uint (value, val);
     uint reply = n_value_get_uint (value);
-    fail_unless (reply == val);
+    ck_assert (reply == val);
 
     n_value_free (value);
     value = NULL;
@@ -201,12 +201,12 @@ START_TEST (test_bool)
 {
     NValue *value = NULL;
     value = n_value_new ();
-    fail_unless (value != NULL);
-    fail_unless (n_value_get_bool (value) == FALSE);
+    ck_assert (value != NULL);
+    ck_assert (n_value_get_bool (value) == FALSE);
     gboolean val = TRUE;
     n_value_set_bool (value, val);
     gboolean reply = n_value_get_bool (value);
-    fail_unless (reply == val);
+    ck_assert (reply == val);
 
     n_value_free (value);
     value = NULL;
@@ -217,12 +217,12 @@ START_TEST (test_pointer)
 {
     NValue *value = NULL;
     value = n_value_new ();
-    fail_unless (value != NULL);
-    fail_unless (n_value_get_pointer (value) == NULL);
+    ck_assert (value != NULL);
+    ck_assert (n_value_get_pointer (value) == NULL);
     gpointer val = (gpointer)value;
     n_value_set_pointer (value, val);
     gpointer reply = n_value_get_pointer (value);
-    fail_unless (reply == val);
+    ck_assert (reply == val);
 
     n_value_free (value);
     value = NULL;
@@ -233,7 +233,7 @@ START_TEST (test_to_string)
 {
     NValue *value = NULL;
     value = n_value_new ();
-    fail_unless (value != NULL);
+    ck_assert (value != NULL);
     const char *str = "NGF";
     const int i = -100;
     const uint ui = 10;
@@ -242,42 +242,42 @@ START_TEST (test_to_string)
     char *expected = "<unknown value>";
 
     char *string = n_value_to_string (value);
-    fail_unless (strcmp (string, expected) == 0);
+    ck_assert (strcmp (string, expected) == 0);
     g_free (string);
     string = NULL;
 	
     n_value_set_string (value, str);
     string = n_value_to_string (value);
     expected = "NGF (string)";
-    fail_unless (strcmp (string, expected) == 0);
+    ck_assert (strcmp (string, expected) == 0);
     g_free (string);
     string = NULL;
 
     n_value_set_int (value, i);
     string = n_value_to_string (value);
     expected = "-100 (int)";
-    fail_unless (strcmp (string, expected) == 0);
+    ck_assert (strcmp (string, expected) == 0);
     g_free (string);
     string = NULL;
 
     n_value_set_uint (value, ui);
     string = n_value_to_string (value);
     expected = "10 (uint)";
-    fail_unless (strcmp (string, expected) == 0);
+    ck_assert (strcmp (string, expected) == 0);
     g_free (string);
     string = NULL;
 
     n_value_set_bool (value, logic);
     string = n_value_to_string (value);
     expected = "TRUE (bool)";
-    fail_unless (strcmp (string, expected) == 0);
+    ck_assert (strcmp (string, expected) == 0);
     g_free (string);
     string = NULL;
 
     n_value_set_pointer (value, point);
     string = n_value_to_string (value);
     expected = g_strdup_printf ("0x%p (pointer)", point);
-    fail_unless (g_strcmp0 (string, expected) == 0);
+    ck_assert (g_strcmp0 (string, expected) == 0);
     g_free (string);
     g_free (expected);
     string = NULL;


### PR DESCRIPTION
Some extra _free() calls on content owned by ngfd types. Added a couple of notes to the headers.

Migrated from deprecated fail_unless() to ck_assert().