### PR TITLE
[ngfd] Consistently handle parameters for which ownership is claimed. JB#61858

### DIFF
--- a/src/include/ngf/proplist.h
+++ b/src/include/ngf/proplist.h
@@ -108,7 +108,7 @@ gboolean    n_proplist_match_exact (const NProplist *a, const NProplist *b);
  * @param key Key
  * @param value Value. Proplist takes ownership of the value.
  */
-void        n_proplist_set         (NProplist *proplist, const char *key, const NValue *value);
+void        n_proplist_set         (NProplist *proplist, const char *key, NValue *value);
 
 /** Get value from proplist
  * @param proplist Proplist

--- a/src/ngf/context.c
+++ b/src/ngf/context.c
@@ -86,8 +86,10 @@ n_context_set_value (NContext *context, const char *key,
 {
     NValue *old_value = NULL;
 
-    if (!context || !key)
+    if (!context || !key) {
+        n_value_free (value);
         return;
+    }
 
     old_value = n_value_copy (n_proplist_get (context->values, key));
     n_proplist_set (context->values, key, value);

--- a/src/ngf/proplist.c
+++ b/src/ngf/proplist.c
@@ -204,12 +204,14 @@ n_proplist_unset (NProplist *proplist, const char *key)
 }
 
 void
-n_proplist_set (NProplist *proplist, const char *key, const NValue *value)
+n_proplist_set (NProplist *proplist, const char *key, NValue *value)
 {
-    if (!proplist || !key || !value)
+    if (!proplist || !key || !value) {
+        n_value_free (value);
         return;
+    }
 
-    g_hash_table_replace (proplist->values, g_strdup (key), (gpointer) value);
+    g_hash_table_replace (proplist->values, g_strdup (key), value);
 }
 
 NValue*

--- a/tests/test-context.c
+++ b/tests/test-context.c
@@ -21,9 +21,9 @@ START_TEST (test_set_get_value)
     ck_assert (n_context_get_value (NULL, key) == NULL);
 
     /* sets value sith some NULL arguments */
-    n_context_set_value (NULL, key, value);
+    n_context_set_value (NULL, key, n_value_copy (value));
     ck_assert (n_context_get_value (context, key) == NULL);
-    n_context_set_value (context, NULL, value);
+    n_context_set_value (context, NULL, n_value_copy (value));
     ck_assert (n_context_get_value (context, key) == NULL);
 
     /* calls set value with valid arguments */

--- a/tests/test-proplist.c
+++ b/tests/test-proplist.c
@@ -386,12 +386,14 @@ START_TEST (test_set_get_unset)
     NValue *result = NULL;
     const char *key = "key";
     
-    n_proplist_set (NULL, key, value);
+    // these should fail to set
+    n_proplist_set (NULL, key, n_value_copy (value));
     ck_assert (n_proplist_is_empty (proplist) == TRUE);
-    n_proplist_set (proplist, NULL, value);
+    n_proplist_set (proplist, NULL, n_value_copy (value));
     ck_assert (n_proplist_is_empty (proplist) == TRUE);
     n_proplist_set (proplist, key, NULL);
     ck_assert (n_proplist_is_empty (proplist) == TRUE);
+    // this should succeed
     n_proplist_set (proplist, key, value);
     ck_assert (n_proplist_size (proplist) == 1);
 


### PR DESCRIPTION
Regardless of success or failure the ownership should be handled consistently. The caller of the methods doesn't even get to know if the operation succeeded by the return value.

In addition the value parameter const on n_proplist_set was quite misleading when the implementation cast is as non-const.