### PR TITLE
[ngfd] Avoid writing unitialized data on ffmemless. JB#62804

### DIFF
--- a/src/plugins/ffmemless/ffmemless.c
+++ b/src/plugins/ffmemless/ffmemless.c
@@ -36,6 +36,7 @@
 int ffmemless_play(int effect_id, int device_file, int play)
 {
 	struct input_event event;
+	memset(&event, 0, sizeof(event));
 
 	event.type = EV_FF;
 	event.code = effect_id;


### PR DESCRIPTION
struct input_event has also embedded struct timeval. Not sure if the content matters, but still getting vibra feedback and random data shouldn't be too good content if the content matters.