### PR TITLE
[ngfd] Fix profile tracker initialized at wrong point. JB#27287

### DIFF
--- a/src/plugins/profile/plugin.c
+++ b/src/plugins/profile/plugin.c
@@ -612,10 +612,10 @@ N_PLUGIN_LOAD (plugin)
     profile_track_add_change_cb  (value_changed_cb, core, NULL);
     profile_track_add_profile_cb (profile_changed_cb, core, NULL);
 
-    profile_tracker_init ();
-
     if (!setup_session_bus_connection (core))
         return FALSE;
+
+    profile_tracker_init ();
 
     return TRUE;
 }


### PR DESCRIPTION
At ngfd start there was a warning:
libprofile: session bus connection requested while blocked

And indeed, here just before profile_tracker_init there is call to profile_connection_disable_autoconnect(),
then profile_tracker_init() tried to get the connection and failed to do anything.