### PR TITLE
Fix ffmemless crash

### DIFF
--- a/rpm/ngfd.spec
+++ b/rpm/ngfd.spec
@@ -78,12 +78,10 @@ This package contains test suite for ngfd.
 
 %build
 %autogen --enable-debug
-make %{?_smp_mflags}
+%make_build
 
 %install
-rm -rf %{buildroot}
 %make_install
-rm -f %{buildroot}/%{_libdir}/ngf/*.la
 
 install -D -m 644 %{SOURCE1} %{buildroot}%{_userunitdir}/ngfd.service
 mkdir -p %{buildroot}%{_userunitdir}/user-session.target.wants
@@ -92,7 +90,6 @@ mkdir -p %{buildroot}%{_userunitdir}/actdead-session.target.wants
 ln -s ../ngfd.service %{buildroot}%{_userunitdir}/actdead-session.target.wants/
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
 %config %{_sysconfdir}/dbus-1/system.d/%{name}.conf
 %{_bindir}/%{name}
@@ -116,23 +113,18 @@ ln -s ../ngfd.service %{buildroot}%{_userunitdir}/actdead-session.target.wants/
 %{_userunitdir}/actdead-session.target.wants/ngfd.service
 
 %files plugin-devel
-%defattr(-,root,root,-)
 %{_includedir}/ngf
 %{_libdir}/pkgconfig/ngf-plugin.pc
 
 %files plugin-fake
-%defattr(-,root,root,-)
 %{_libdir}/ngf/libngfd_fake.so
 %{_libdir}/ngf/libngfd_test_fake.so
 
 %files settings-basic
-%defattr(-,root,root,-)
 %{_datadir}/ngfd/
 
 %files plugin-doc
-%defattr(-,root,root,-)
 %{_docdir}/ngfd-plugin/html
 
 %files tests
-%defattr(-,root,root,-)
 /opt/tests/ngfd

--- a/src/ngf/core-player.c
+++ b/src/ngf/core-player.c
@@ -714,7 +714,7 @@ n_core_complete_sink (NCore *core, NSinkInterface *sink, NRequest *request)
     if (!request->sinks_playing)
         return;
 
-    if (request->stop_source_id > 0){
+    if (request->stop_source_id > 0) {
         N_DEBUG (LOG_CAT "already completing request '%s'", request->name);
         return;
     }  

--- a/src/plugins/ffmemless/ffmemless.c
+++ b/src/plugins/ffmemless/ffmemless.c
@@ -126,6 +126,7 @@ int ffmemless_evdev_file_close(int file)
 	return close(file);
 }
 
-int ffmemless_has_feature(__u16 type, unsigned long features[4]) {
+int ffmemless_has_feature(__u16 type, unsigned long features[4])
+{
 	return test_bit(type, features);
 }

--- a/src/plugins/ffmemless/plugin.c
+++ b/src/plugins/ffmemless/plugin.c
@@ -104,6 +104,7 @@ static int ffm_setup_device(const NProplist *props, int *dev_fd)
 		return 0;
 	}
 }
+
 static void ffm_close_device(int fd)
 {
 	ffmemless_evdev_file_close(fd);
@@ -266,7 +267,7 @@ static int ffm_setup_default_effect(GHashTable *effects, int dev_fd)
 	// drivers which use FF_PERIODIC only with FF_CUSTOM waveform..
 	// https://github.com/torvalds/linux/blob/master/drivers/input/ff-core.c#L350
 	if (ffmemless_has_feature(FF_CONSTANT, ffm.features)) {
-		N_DEBUG (LOG_CAT "Using constant default effect, rumble is %d", 
+		N_DEBUG (LOG_CAT "Using constant default effect, rumble is %d",
 			(ffmemless_has_feature(FF_RUMBLE, ffm.features)));
 		ff.type = FF_CONSTANT;
 		ff.replay.length = NGF_DEFAULT_DURATION;
@@ -303,7 +304,7 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 	struct ffm_effect_data *data;
 	GHashTableIter iter;
 
-	if(!effects || !props) {
+	if (!effects || !props) {
 		N_WARNING (LOG_CAT "ffm_setup_effects: invalid parameters");
 		return -1;
 	}
@@ -344,7 +345,7 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 		}
 
 		if (data->id != -1) {
-			if(ffmemless_erase_effect(data->id, ffm.dev_file)) {
+			if (ffmemless_erase_effect(data->id, ffm.dev_file)) {
 				N_WARNING (LOG_CAT "Failed to remove id %d",
 								data->id);
 				continue;
@@ -538,6 +539,7 @@ static int ffm_setup_effects(const NProplist *props, GHashTable *effects)
 	}
 
 	return 0;
+
 ffm_eff_error1:
 	g_hash_table_destroy(ffm.effects);
 	return -1;
@@ -589,7 +591,7 @@ static int ffm_play(struct ffm_effect_data *data, int play)
 					data->poll_id = 0;
 				}
 				return FALSE;
-			} 
+			}
 		}
 
 		if (ffmemless_play(data->cached_effect.id, ffm.dev_file, play))
@@ -701,6 +703,7 @@ static int ffm_sink_prepare(NSinkInterface *iface, NRequest *request)
 
 	return TRUE;
 }
+
 static int ffm_sink_play(NSinkInterface *iface, NRequest *request)
 {
 	struct ffm_effect_data *data;
@@ -712,10 +715,11 @@ static int ffm_sink_play(NSinkInterface *iface, NRequest *request)
 
 	N_DEBUG (LOG_CAT "play id %d, repeat %d times, iface 0x%x, "
 			 "req 0x%x data 0x%x", data->id, data->repeat,
-			data->iface, data->request, data);
+			 data->iface, data->request, data);
 
 	return ffm_play(data, data->repeat);
 }
+
 static int ffm_sink_pause(NSinkInterface *iface, NRequest *request)
 {
 	struct ffm_effect_data *data;
@@ -733,6 +737,7 @@ static int ffm_sink_pause(NSinkInterface *iface, NRequest *request)
 	/* no pause possible for vibra effects, just stop */
 	return ffm_play(data, 0);
 }
+
 static void ffm_sink_stop(NSinkInterface *iface, NRequest *request)
 {
 	struct ffm_effect_data *data;

--- a/src/plugins/ffmemless/plugin.c
+++ b/src/plugins/ffmemless/plugin.c
@@ -572,7 +572,9 @@ static int ffm_play(struct ffm_effect_data *data, int play)
 		}
 		N_DEBUG (LOG_CAT "Starting playback %d", data->id);
 	} else {
-		ffm_playback_done(data);
+		if (ffm.cache_effects) {
+			ffmemless_erase_effect(data->cached_effect.id, ffm.dev_file);
+		}
 		N_DEBUG (LOG_CAT "Stopping playback %d", data->id);
 	}
 

--- a/src/plugins/gst/plugin.c
+++ b/src/plugins/gst/plugin.c
@@ -951,7 +951,8 @@ update_fade_effect (FadeEffect *effect, gdouble elapsed, gdouble volume)
 }
 
 static gboolean
-gst_sink_synchronize_cb (gpointer userdata) {
+gst_sink_synchronize_cb (gpointer userdata)
+{
     StreamData *stream = userdata;
 
     /* If our pipeline is not yet ready to be played (not yet in state GST_STATE_PAUSED
@@ -966,7 +967,8 @@ gst_sink_synchronize_cb (gpointer userdata) {
 }
 
 static gboolean
-gst_sink_fake_play_complete_cb (gpointer userdata) {
+gst_sink_fake_play_complete_cb (gpointer userdata)
+{
     StreamData *stream = userdata;
 
     stream->fake_play_source = 0;
@@ -1173,7 +1175,8 @@ cleanup (StreamData *stream)
 }
 
 static void
-stream_stop (StreamData *stream) {
+stream_stop (StreamData *stream)
+{
     N_DEBUG (LOG_CAT "stop");
 
     stream_clear_delays (stream);
@@ -1189,7 +1192,8 @@ stream_stop (StreamData *stream) {
 }
 
 static void
-gst_sink_stop_all_cb (gpointer userdata) {
+gst_sink_stop_all_cb (gpointer userdata)
+{
     StreamData *stream = userdata;
 
     stream_clear_delays (stream);

--- a/src/plugins/tonegen/stream.c
+++ b/src/plugins/tonegen/stream.c
@@ -251,7 +251,7 @@ void stream_destroy(struct stream *stream)
 #endif
 
 
-    for (prev=(struct stream *)&ausrv->streams;  prev->next;  prev=prev->next){
+    for (prev=(struct stream *)&ausrv->streams;  prev->next;  prev=prev->next) {
         if (prev->next == stream) {
             pastr = stream->pastr;
             battr = pa_stream_get_buffer_attr(pastr);


### PR DESCRIPTION
Main commit

    [ngfd] Fix crash with ffmemless plugin. JB#62892
    
    When there was a ffm_sink_stop() call, it ended up in calling
    n_sink_interface_complete(). This wasn't nice if the stop call was coming
    from core-player.c / n_core_request_done_cb(), and then
    'interface complete' triggered another async callback to already deleted
    request instance.
    
    The ffm_play() here is handling stop and pause requests, it shouldn't
    do any extra signalling for the request status.
    
    This seems to be a regression from commit e452a00fe, supposedly for
    doing the erase effect. Rest shouldn't be needed on stopping.
