### PR TITLE
Fixes crashes due to stale timers

### DIFF
--- a/src/include/ngf/log.h
+++ b/src/include/ngf/log.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Nokia Corporation.
  * Contact: Xun Chen <xun.chen@nokia.com>
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * This work is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,10 +29,13 @@ typedef enum _NLogTarget
 {
     /** Suppress logging */
     N_LOG_TARGET_NONE = 0,
-    
+
+    /** Direct logging to stderr */
+    N_LOG_TARGET_STDERR,
+
     /** Direct logging to stdout */
     N_LOG_TARGET_STDOUT,
-    
+
     /** Direct logging to syslog */
     N_LOG_TARGET_SYSLOG
 } NLogTarget;
@@ -89,7 +93,7 @@ void n_log_message    (NLogLevel level, const char *function, int line, const ch
 /** Log function enter message */
 #define N_ENTER(...) \
     do {  n_log_message (N_LOG_LEVEL_ENTER, (const char*) __FUNCTION__, __LINE__, __VA_ARGS__); } while(0)
-    
+
 /** Log debug message */
 #define N_DEBUG(...) \
     do { n_log_message (N_LOG_LEVEL_DEBUG, (const char*) __FUNCTION__, __LINE__, __VA_ARGS__); } while(0)

--- a/src/ngf/log.c
+++ b/src/ngf/log.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Nokia Corporation.
  * Contact: Xun Chen <xun.chen@nokia.com>
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * This work is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,14 +25,15 @@
 #include <syslog.h>
 #include <string.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include <ngf/log.h>
 
 #define LOG_CAT "log: "
 
 static NLogLevel       _log_level       = N_LOG_LEVEL_ENTER;
-static NLogTarget      _log_target      = N_LOG_TARGET_STDOUT;
-static struct timespec _log_clock_start = { 0, 0 };
+static NLogTarget      _log_target      = N_LOG_TARGET_STDERR;
+static uint64_t        _log_clock_start = 0;
 
 static int
 n_log_syslog_priority_from_level (NLogLevel category)
@@ -71,21 +73,33 @@ n_log_get_level ()
     return _log_level;
 }
 
+static const char *
+n_log_target_to_string(NLogTarget target)
+{
+    switch (target) {
+    case N_LOG_TARGET_NONE:   return "none";
+    case N_LOG_TARGET_STDERR: return "stderr";
+    case N_LOG_TARGET_STDOUT: return "stdout";
+    case N_LOG_TARGET_SYSLOG: return "syslog";
+    default:                  return "unknown";
+    }
+}
+
 void
 n_log_set_target (NLogTarget target)
 {
     if (target == _log_target)
         return;
 
-    _log_target = target;
-    if (target == N_LOG_TARGET_SYSLOG) {
-        openlog ("ngfd", 0, LOG_DAEMON);
-        N_INFO (LOG_CAT "logging enabled to syslog");
-    }
-    else {
-        N_INFO (LOG_CAT "logging enabled to stdout.");
+    if (_log_target == N_LOG_TARGET_SYSLOG)
         closelog();
-    }
+
+    _log_target = target;
+
+    if (_log_target == N_LOG_TARGET_SYSLOG)
+        openlog ("ngfd", 0, LOG_DAEMON);
+
+    N_INFO (LOG_CAT "logging enabled to %s", n_log_target_to_string(target));
 }
 
 NLogTarget
@@ -120,34 +134,26 @@ n_log_level_to_string (NLogLevel category)
     return "UNKNOWN";
 }
 
+static uint64_t
+n_log_get_clock_tick(void)
+{
+    struct timespec ts = {};
+    clock_gettime(CLOCK_BOOTTIME, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
 static void
 n_log_get_clock_stamp (char *buffer, size_t len)
 {
-    struct timespec res;
-    struct timespec ts;
-    long ms = 0;
+    uint64_t ms = n_log_get_clock_tick() - _log_clock_start;
 
-    if (clock_gettime (CLOCK_MONOTONIC, &ts) < 0) {
-        snprintf (buffer, len, "no_time");
-        return;
-    }
-
-    res.tv_sec  = ts.tv_sec - _log_clock_start.tv_sec;
-    res.tv_nsec = ts.tv_nsec - _log_clock_start.tv_nsec;
-    ms = res.tv_nsec / 1000000;
-
-    snprintf (buffer, len, "%lu.%.3lu",  (long) res.tv_sec, ms);
+    snprintf (buffer, len, "%" PRIu64 ".%03" PRIu64 "",  ms / 1000u, ms % 1000u);
 }
 
 void
 n_log_initialize (NLogLevel level)
 {
-    struct timespec ts;
-
-    if (clock_gettime (CLOCK_MONOTONIC, &ts) < 0)
-        return;
-
-    _log_clock_start = ts;
+    _log_clock_start = n_log_get_clock_tick();
     _log_level       = level;
 
     N_DEBUG (LOG_CAT "clock time reset");
@@ -168,14 +174,22 @@ n_log_message (NLogLevel category, const char *function, int line,
 
     va_list fmt_args;
     va_start (fmt_args, fmt);
-    vsnprintf (buf, 256, fmt, fmt_args);
+    vsnprintf (buf, sizeof buf, fmt, fmt_args);
     va_end (fmt_args);
 
-    if (_log_target == N_LOG_TARGET_SYSLOG) {
-        syslog (n_log_syslog_priority_from_level (category), "%s", buf);
-    }
-    else if (_log_target == N_LOG_TARGET_STDOUT) {
-        n_log_get_clock_stamp (clock_stamp, 256);
+    switch (_log_target) {
+    case N_LOG_TARGET_NONE:
+        break;
+    case N_LOG_TARGET_STDERR:
+        n_log_get_clock_stamp (clock_stamp, sizeof clock_stamp);
+        fprintf (stderr, "[%s] %s: %s\n", clock_stamp, n_log_level_to_string (category), buf);
+        break;
+    case N_LOG_TARGET_STDOUT:
+        n_log_get_clock_stamp (clock_stamp, sizeof clock_stamp);
         fprintf (stdout, "[%s] %s: %s\n", clock_stamp, n_log_level_to_string (category), buf);
+        break;
+    case N_LOG_TARGET_SYSLOG:
+        syslog (n_log_syslog_priority_from_level (category), "%s", buf);
+        break;
     }
 }

--- a/src/ngf/main.c
+++ b/src/ngf/main.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Nokia Corporation.
  * Contact: Xun Chen <xun.chen@nokia.com>
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * This work is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,6 +27,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
+#include <stdio.h>
 
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
@@ -176,11 +178,16 @@ remove_signal_handlers (AppData *app)
 int
 main (int argc, char *argv[])
 {
-    AppData app;
+    /* In case we should log to stdout / stderr,
+     * we do not want to use block buffering. */
+    setlinebuf(stdout);
+    setlinebuf(stderr);
 
-    memset (&app, 0, sizeof (app));
-    app.default_loglevel = N_LOG_LEVEL_ERROR;
-    app.use_default_loglevel = TRUE;
+    AppData app = {
+        .default_loglevel = N_LOG_LEVEL_WARNING,
+        .use_default_loglevel = TRUE,
+    };
+
     n_log_initialize (app.default_loglevel);
 
     if (!parse_cmdline (argc, argv, &app))

--- a/src/ngf/request-internal.h
+++ b/src/ngf/request-internal.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Nokia Corporation.
  * Contact: Xun Chen <xun.chen@nokia.com>
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * This work is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -38,9 +39,9 @@ struct _NRequest
     NProplist       *original_properties;
 
     guint            id;                    /* unique request identifier */
-    NEvent          *event;
-    NCore           *core;
-    NInputInterface *input_iface;
+    NEvent          *event;                 /* borrowed reference */
+    NCore           *core;                  /* borrowed reference */
+    NInputInterface *input_iface;           /* borrowed reference */
 
     gboolean         is_paused;
     gboolean         is_fallback;
@@ -56,7 +57,7 @@ struct _NRequest
     GList           *sinks_playing;         /* sinks currently playing */
     GList           *sinks_resync;
     GList           *stop_list;
-    NSinkInterface  *master_sink;
+    NSinkInterface  *master_sink;           /* borrowed reference */
 
     guint            max_timeout_id;
     guint            timeout_ms;

--- a/src/ngf/request.c
+++ b/src/ngf/request.c
@@ -42,7 +42,7 @@ n_request_copy (const NRequest *request)
 
     copy                = g_slice_new0 (NRequest);
     copy->id            = request->id;
-    copy->name          = request->name ? g_strdup (request->name) : NULL;
+    copy->name          = g_strdup (request->name);
     copy->input_iface   = request->input_iface;
     if (request->original_properties)
         copy->properties = n_proplist_copy (request->original_properties);
@@ -71,7 +71,7 @@ n_request_new_with_event_and_properties (const char *event, const NProplist *pro
 
     NRequest *request   = n_request_new ();
     request->name       = g_strdup (event);
-    request->properties = n_proplist_copy ((NProplist*) properties);
+    request->properties = n_proplist_copy (properties);
 
     return request;
 }
@@ -114,13 +114,13 @@ n_request_free (NRequest *request)
 unsigned int
 n_request_get_id (NRequest *request)
 {
-    return (request != NULL) ? request->id : 0;
+    return request ? request->id : 0;
 }
 
 const char*
 n_request_get_name (NRequest *request)
 {
-    return (request != NULL) ? (const char*) request->name : NULL;
+    return request ? request->name : NULL;
 }
 
 void
@@ -136,7 +136,7 @@ n_request_set_properties (NRequest *request, NProplist *properties)
 const NProplist*
 n_request_get_properties (NRequest *request)
 {
-    return (request != NULL) ? (const NProplist*) request->properties : NULL;
+    return request ? request->properties : NULL;
 }
 
 void
@@ -178,7 +178,7 @@ n_request_is_fallback (NRequest *request)
 const NEvent*
 n_request_get_event (NRequest *request)
 {
-    return (request != NULL) ? (const NEvent*) request->event : NULL;
+    return request ? request->event : NULL;
 }
 
 void
@@ -193,7 +193,5 @@ n_request_set_timeout (NRequest *request, guint timeout)
 guint
 n_request_get_timeout (NRequest *request)
 {
-    return (request != NULL) ? request->timeout_ms : 0;
+    return request ? request->timeout_ms : 0;
 }
-
-


### PR DESCRIPTION
Example of timer crash backtrace we're trying to address:

```
Thread 1 (Thread 0x7985b2c010 (LWP 3398)):
#0  g_type_check_instance_is_fundamentally_a (type_instance=type_instance@entry=0x7985206454 <tone_destroy_callback>, fundamental_type=fundamental_type@entry=80) at ../gobject/gtype.c:4184
        node = <optimized out>
#1  0x0000007984abdd68 in g_object_unref (_object=0x7985206454 <tone_destroy_callback>) at ../gobject/gobject.c:3810
        _g_boolean_var_135 = <optimized out>
        object = 0x7985206454 <tone_destroy_callback>
        old_ref = <optimized out>
        __func__ = "g_object_unref"
        retry_atomic_decrement1 = <optimized out>
#2  0x0000007984caa8a8 in free_volume (stream=0x150fbc70) at plugin.c:385
No locals.
#3  free_pipeline (stream=0x150fbc70) at plugin.c:687
        __FUNCTION__ = "free_pipeline"
#4  cleanup (stream=stream@entry=0x150fbc70) at plugin.c:1166
No locals.
#5  0x0000007984cab784 in stream_stop (stream=0x150fbc70) at plugin.c:1189
        __FUNCTION__ = "stream_stop"
#6  0x000000000040a5e4 in n_core_stop_sinks (request=0x150e1bc0, sinks=<optimized out>) at core-player.c:260
        iter = 0x1510bb80
        sink = <optimized out>
#7  n_core_request_done_cb (userdata=0x150e1bc0) at core-player.c:339
        request = 0x150e1bc0
        fallback = 0x0
        core = 0x14fdb6f0
        has_fallbacks = 0
        __FUNCTION__ = "n_core_request_done_cb"
#8  0x000000798594c3c4 in g_main_dispatch (context=context@entry=0x14fdb4c0) at ../glib/gmain.c:3476
```