### PR TITLE
[ngfd] Lower warning for no sinks handling feedback to debug level. JB#63363

### DIFF
--- a/src/ngf/core-player.c
+++ b/src/ngf/core-player.c
@@ -506,10 +506,11 @@ n_core_play_request (NCore *core, NRequest *request)
     all_sinks = n_core_query_capable_sinks (request);
     all_sinks = n_core_fire_filter_sinks_hook (request, all_sinks);
 
-    /* if no sinks left, then nothing to do. */
+    /* if no sinks left, then nothing to do. can be that no sinks support the event
+       or that their state / configuration has specific feedback disabled */
 
     if (!all_sinks) {
-        N_WARNING (LOG_CAT "no sinks that can handle the request '%s'",
+        N_DEBUG (LOG_CAT "no sinks that can and want to handle the request '%s'",
             request->name);
         goto fail_request;
     }


### PR DESCRIPTION
Commit e1ec7892b8e enabled warning logging by default. With e.g. haptic feedbacks of for touch screen events, it meant having these in journal:
WARNING: core: no sinks that can handle the request 'feedback_press_strong'

Which sounds scarier than it is. In this case n_haptic_can_handle() returns false based on configuration. Might be nice differentiating better between anything able to handle and anything willing to handle right now, but that would be bigger changes. So now just adjusting logging level and message a bit now so that it's not confused as ngfd not being capable for handling the event.