### PR TITLE
Fix interface

### DIFF
--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -52,15 +52,19 @@ START_TEST (test_get_params)
 }
 END_TEST
 
-static int
-plugin_play ()
+
+static int plugin_play(NSinkInterface *iface, NRequest *request)
 {
+    (void)iface;
+    (void)request;
     return TRUE;
 }
 
-static void
-plugin_stop ()
-{}
+static void plugin_stop(NSinkInterface *iface, NRequest *request)
+{
+    (void)iface;
+    (void)request;
+}
 
 START_TEST (test_register_sink)
 {


### PR DESCRIPTION
I got following error while compiling.
```
test-plugin.c: In function ‘test_register_sink_fn’:
test-plugin.c:73:23: error: initialization of ‘int (*)(NSinkInterface *, NRequest *)’ {aka ‘int (*)(struct _NSinkInterface *, struct _NRequest *)’} from incompatible pointer type ‘int (*)(void)’ [-Wincompatible-pointer-types]
   73 |         .play       = plugin_play,
      |                       ^~~~~~~~~~~
test-plugin.c:73:23: note: (near initialization for ‘decl.play’)
test-plugin.c:56:1: note: ‘plugin_play’ declared here
   56 | plugin_play ()
      | ^~~~~~~~~~~
test-plugin.c:75:23: error: initialization of ‘void (*)(NSinkInterface *, NRequest *)’ {aka ‘void (*)(struct _NSinkInterface *, struct _NRequest *)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
   75 |         .stop       = plugin_stop
      |                       ^~~~~~~~~~~
test-plugin.c:75:23: note: (near initialization for ‘decl.stop’)
test-plugin.c:62:1: note: ‘plugin_stop’ declared here
   62 | plugin_stop ()
      | ^~~~~~~~~~~
```